### PR TITLE
docs: add decision index and issue status navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,150 @@
 [中文版](README_cn.md)
 
-Original repository: https://github.com/lightcoloror/PicInterpreter
+# Tuyujia — Pictogram-based AAC for Aphasia
 
-# Tuyujia
+Tuyujia is an open-source AAC (Augmentative and Alternative Communication) app for people with aphasia and their caregivers. Patients select pictograms to express needs; the app generates natural-language sentences and reads them aloud. Caregivers speak or type — the app converts their words back into pictogram sequences the patient can understand.
 
-Tuyujia is a picture-based assisted communication app for people with aphasia and their caregivers. Users can express needs by selecting pictures, then the system generates candidate sentences and reads them aloud. It also supports converting caregiver-entered text or speech back into picture sequences to help patients understand.
+**The hard problems:**
 
-The project currently uses `Next.js + React 19 + TypeScript`, with `Dexie` for local `IndexedDB` data. AI requests are routed through the Next.js backend under `app/api`, so the frontend no longer stores any API keys or tokens.
+1. **Colloquial Chinese → pictogram sequences, reliably.** Real caregivers speak in dialect, incomplete sentences, and mixed word order. The app needs to map "妈妈今天肚子有点不舒服想吃点清淡的" to the right picture sequence — not just when the input is clean, but when it isn't.
+
+2. **Context makes communication better.** The same words mean different things in a hospital room, at a meal, or during rehabilitation. Scene and conversational history should shape which pictograms are suggested and in what order.
+
+3. **No network, no problem.** Basic bidirectional communication must work on a plane, in a rural clinic, or when the Wi-Fi drops. Offline is not a degraded mode — it is the baseline.
+
+---
+
+## Screenshots
+
+> Screenshots coming soon. Run `npm run dev` to see the app at `http://localhost:3001`.
+>
+> *Want to contribute screenshots or a demo GIF? Open a PR adding images to `docs/screenshots/`.*
+
+---
+
+## Quick Start
+
+No database. No AI key. The core expression and receiver flows run entirely in the browser.
+
+```bash
+npm install
+npm run dev
+# Open http://localhost:3001
+```
+
+- **No AI key**: sentence generation falls back to offline templates.
+- **No MySQL**: all core flows use local IndexedDB (Dexie). Cloud sync is optional.
+- **Service Worker is off by default**: no cache issues during development.
+
+Full environment setup is in [Environment Variables](#environment-variables).
+
+---
+
+## Product Principles
+
+These guide every technical and UX decision:
+
+- **Offline-first.** Core bidirectional communication must work without network access.
+- **AI assists, does not control.** LLM-assisted resegmentation improves results; the caregiver always has the last word.
+- **Corrections make the app smarter.** Every time a caregiver swaps or reorders a pictogram, that signal should eventually feed back into matching quality.
+- **Patient-facing UI is icon-first.** Large targets, high contrast, no explanatory text on the patient screen.
+- **Pictograms are communication assets.** They carry meaning, ordering, and context — not just image files.
+
+---
+
+## Current Priorities
+
+1. **Receiver-side data persistence** — the receiver flow currently writes nothing to history ([#26](https://github.com/picinterpreter/picinterpreter/issues/26))
+2. **Text-to-pictogram matching quality** — synonym gaps, dialect wording, compound phrases ([#8](https://github.com/picinterpreter/picinterpreter/issues/8), [#15](https://github.com/picinterpreter/picinterpreter/issues/15))
+3. **Bidirectional conversation history for LLM context** ([#31](https://github.com/picinterpreter/picinterpreter/issues/31))
+4. **Accessibility and icon-first patient controls** ([#6](https://github.com/picinterpreter/picinterpreter/issues/6))
+5. **E2E and real-device test coverage** ([#33](https://github.com/picinterpreter/picinterpreter/issues/33))
+
+---
+
+## How to Contribute
+
+You do not need to work on AI to contribute. The most needed work spans matching logic, accessibility, pictogram data, testing, and UI.
+
+**Good first issues** (self-contained, no deep domain knowledge required):
+
+- [#16 — Voice waveform visualisation during speech input](https://github.com/picinterpreter/picinterpreter/issues/16)
+- [#6 — Icon-first patient controls across the patient-facing UI](https://github.com/picinterpreter/picinterpreter/issues/6)
+
+**Contribution areas by skill:**
+
+| Area | Issues / Labels |
+|------|----------------|
+| Text matching & NLP | [#8](https://github.com/picinterpreter/picinterpreter/issues/8), [#15](https://github.com/picinterpreter/picinterpreter/issues/15), label: `ai` |
+| Accessibility | [#6](https://github.com/picinterpreter/picinterpreter/issues/6), label: `accessibility` |
+| Pictogram data & imports | [#11](https://github.com/picinterpreter/picinterpreter/issues/11), [#30](https://github.com/picinterpreter/picinterpreter/issues/30), label: `data` |
+| Frontend / UI | [#14](https://github.com/picinterpreter/picinterpreter/issues/14), [#23](https://github.com/picinterpreter/picinterpreter/issues/23), label: `ui` |
+| Testing | [#33](https://github.com/picinterpreter/picinterpreter/issues/33), label: `help wanted` |
+| Backend / sync | [#26](https://github.com/picinterpreter/picinterpreter/issues/26), [#27](https://github.com/picinterpreter/picinterpreter/issues/27), label: `backend` |
+
+For larger changes, open an issue first to align on direction before writing code.
+
+---
 
 ## Core Features
 
-- Expression mode: browse picture cards by category, compose an expression, generate candidate sentences, and play them aloud.
-- Receiver mode: enter text or speech and automatically match it to a picture sequence, with support for deletion, replacement, sorting, and fullscreen display.
-- AI sentence generation: template-based generation works offline by default; online models can be enabled by configuring backend AI environment variables.
-- Speech output: browser-native TTS, with voice preview, speech rate, and voice selection settings.
-- Speech input: browser Web Speech API support.
-- Local data persistence: categories, pictures, expression records, saved phrases, and text-to-picture results are stored locally in the browser.
-- First-use guide, emergency help panel, quick common phrases, conversation history, category visibility settings, and high-contrast mode.
-- Debug tools: built-in picture matching validation page and ARASAAC import tool.
+- **Expression mode** — browse pictogram cards by category, compose an expression, generate candidate sentences, and play them aloud.
+- **Receiver mode** — enter text or speech, auto-match to a pictogram sequence, with deletion, replacement, reordering, and fullscreen patient display.
+- **AI sentence generation** — offline template-based by default; configurable online LLM for higher quality.
+- **Speech output** — browser-native TTS with voice preview, speech rate, and voice selection.
+- **Speech input** — Web Speech API; primary path on iOS/Safari.
+- **Local-first persistence** — categories, pictograms, expression records, saved phrases stored in IndexedDB (Dexie).
+- **Optional cloud sync** — expressions and saved phrases sync to MySQL via outbox pattern.
+- First-use guide, emergency help panel, quick phrases, conversation history, category visibility, high-contrast mode.
+- **Debug tools** — pictogram matching validator at `/debug`, ARASAAC batch import at `/import`.
+
+---
+
+## Architecture
+
+The app is offline-first: Dexie (IndexedDB) is the primary store. MySQL is optional cloud sync.
+
+```
+Expression flow:   Category browser → Pictogram selection → NLG → TTS output
+Receiver flow:     Voice/text input → Tokenization → Pictogram matching → Review → Fullscreen
+Data:              Dexie (local, always) ← → MySQL via Prisma (optional, sync)
+AI:                Next.js API routes proxy to any OpenAI-compatible LLM (optional)
+```
+
+**Architecture docs:**
+- [Decision index — confirmed decisions and open questions](docs/decision-index.md)
+- [Architecture review and key decisions](docs/ARCHITECTURE_REVIEW.md)
+- [ADR-001: Receiver data model](docs/ADR-001-receiver-data-model.md)
+- [ASR pipeline research](docs/ASR_PIPELINE_RESEARCH.md)
+- [Product requirements](docs/prd.md)
+
+---
+
+## Tech Stack
+
+- React 19 + TypeScript
+- Next.js (App Router + Route Handlers)
+- Tailwind CSS 4
+- Zustand (state)
+- Dexie (IndexedDB)
+- Prisma + MySQL (optional sync)
+- Vitest (unit tests)
+
+---
 
 ## Requirements
 
-- Node.js 18+. The project is currently developed with `Node 24`.
-- npm
-
-Install dependencies:
+Node.js 18+. Developed with Node 24.
 
 ```bash
 npm install
 ```
 
+---
+
 ## Environment Variables
 
-Copy `.env.example` to `.env.local` and fill in the values you need:
+Copy `.env.example` to `.env.local`:
 
 ```env
 DATABASE_URL=mysql://root:password@127.0.0.1:3306/picinterpreter
@@ -43,125 +155,111 @@ OPENSYMBOLS_SECRET=
 NEXT_PUBLIC_ENABLE_SERVICE_WORKER=false
 ```
 
-- `DATABASE_URL`: MySQL connection string used by the Prisma driver adapter.
-- `AI_API_KEY`: required server-side API key for the upstream LLM.
-- `AI_BASE_URL`: OpenAI-compatible API endpoint. Defaults to `https://api.openai.com/v1`.
-- `AI_MODEL`: default model name. Defaults to `gpt-4o-mini`.
-- `OPENSYMBOLS_SECRET`: optional. When configured, runtime missing-image backfill will query OpenSymbols after ARASAAC misses. This value is only read on the server.
-- `NEXT_PUBLIC_ENABLE_SERVICE_WORKER`: whether to enable the frontend Service Worker. Defaults to `false` and is only enabled when explicitly set to `true`.
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DATABASE_URL` | Optional | MySQL connection string. Omit to run fully local. |
+| `AI_API_KEY` | Optional | LLM API key. Without it, sentence generation uses offline templates. |
+| `AI_BASE_URL` | Optional | Any OpenAI-compatible endpoint. Defaults to `https://api.openai.com/v1`. |
+| `AI_MODEL` | Optional | Model name. Defaults to `gpt-4o-mini`. |
+| `OPENSYMBOLS_SECRET` | Optional | Enables OpenSymbols as a fallback when ARASAAC returns no image. Server-only. |
+| `NEXT_PUBLIC_ENABLE_SERVICE_WORKER` | Optional | Enable PWA Service Worker. Defaults to `false`. |
 
-`NEXT_PUBLIC_ENABLE_SERVICE_WORKER` is injected into the frontend at build time. All other variables are read only by the Next.js server.
+`NEXT_PUBLIC_ENABLE_SERVICE_WORKER` is injected at build time. All other variables are server-only.
 
-Recommended conventions:
+**Conventions:**
+- Local dev: `.env.local`
+- CI: write `.env.production` from GitHub Actions only when the build phase needs it
+- Production: inject variables via `systemd`, `pm2`, or your container platform — not via `.env.local` on the server (it can silently override `.env.production`)
 
-- Local development: use `.env.local`.
-- Repository example: keep `.env.example`, and do not commit real secrets.
-- CI builds: write `.env.production` from GitHub Actions only when the build phase truly needs it.
-- Production runtime: prefer injecting environment variables directly through `systemd`, `pm2`, or your container platform instead of relying on environment files on the server.
+---
 
-Why:
-
-- Local development in this project already uses `.env.local`.
-- In `production`, Next.js reads `process.env` first, then `.env.production.local`, `.env.local`, `.env.production`, and `.env`. If both `.env.local` and `.env.production` exist on the server, `.env.local` can override `.env.production`.
-- For that reason, keeping `.env.local` on the server long-term is not recommended. It can easily lead to a situation where CI uploaded `.env.production`, but the runtime values do not actually take effect.
-
-## Local Development
+## Development Commands
 
 ```bash
-npm run dev
+npm run dev              # Start dev server at http://localhost:3001
+npm run build            # Production build
+npm run start            # Start production build locally
+npm run lint             # ESLint
+npm run test             # Vitest (run once)
+npm run test:watch       # Vitest (watch mode)
+npm run test:coverage    # Vitest with coverage report
+npm run prisma:generate  # Generate Prisma client
+npm run prisma:push      # Push schema to MySQL (first-time setup)
 ```
 
-Default port: `http://localhost:3001`
+---
 
 ## AI Backend API
 
-The current API is implemented with Next.js Route Handlers:
+Implemented as Next.js Route Handlers:
 
-- `GET /api/ai/health`: read the backend AI configuration status.
-- `POST /api/ai/sentences`: generate candidate sentences.
-- `POST /api/ai/resegment`: AI-assisted word resegmentation.
-- `POST /api/pictograms/search`: runtime missing-image backfill; the server queries specialized AAC picture libraries and the frontend writes results into local IndexedDB.
-- `POST /api/client/bootstrap`: register or restore an anonymous device identity and set an HttpOnly device cookie.
-- `POST /api/sync/push`: push local `expressions` / `saved_phrases` changes to server-side MySQL.
-- `GET /api/sync/pull`: pull server-side changes by incremental cursor and replay them into local Dexie.
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/ai/health` | GET | Check backend AI configuration status |
+| `/api/ai/sentences` | POST | Generate candidate sentences |
+| `/api/ai/resegment` | POST | AI-assisted word resegmentation |
+| `/api/pictograms/search` | POST | Runtime missing-image backfill (ARASAAC / OpenSymbols) |
+| `/api/client/bootstrap` | POST | Register or restore anonymous device identity |
+| `/api/sync/push` | POST | Push local expression/phrase changes to MySQL |
+| `/api/sync/pull` | GET | Pull server changes by incremental cursor |
 
-The frontend only calls these internal endpoints. The actual `API Key`, `Base URL`, and `Model` are controlled by server-side environment variables.
+The frontend only calls these internal endpoints. API keys are never exposed to the client.
 
-## MySQL Sync Architecture
+---
 
-- The frontend continues to use `Dexie` as the local primary store to preserve the offline experience.
-- The server connects to MySQL 8 through `Prisma 6 + mysql`.
-- The cloud-synced data currently includes only `expressions` and `saved_phrases`.
-- On first open, the app automatically bootstraps an anonymous device identity. After formal login is added in the future, anonymous user data can be merged into an account user.
-- The local Dexie database now includes `syncOutbox` and `syncState` tables for background sync and incremental cursor management.
+## Data and Storage
 
-To initialize the database for the first time:
+- Seed data: [`public/seed/categories.json`](public/seed/categories.json) and [`public/seed/pictograms.json`](public/seed/pictograms.json)
+- On first load (or seed version upgrade), seed data is imported into IndexedDB
+- User expression records, saved phrases, and settings survive seed re-imports
+- First-use guide state and UI preferences are in `localStorage`
+- Database initialization: [`src/db/index.ts`](src/db/index.ts)
+
+---
+
+## MySQL Sync (Optional)
+
+- Dexie remains the local primary store — offline experience is always preserved
+- MySQL 8 via Prisma is used for cross-device sync
+- Synced tables: `expressions`, `saved_phrases`
+- On first open, the app bootstraps an anonymous device identity (future: merge into account on login)
+- Dexie includes `syncOutbox` and `syncState` tables for background sync and cursor management
+
+First-time database setup:
 
 ```bash
 npm run prisma:generate
 npm run prisma:push
 ```
 
-## Common Commands
-
-```bash
-npm run dev
-npm run build
-npm run start
-npm run prisma:generate
-npm run prisma:push
-npm run deploy:aliyun -- --host root@1.2.3.4 --path /opt/picinterpreter
-npm run lint
-npm run test
-npm run test:watch
-npm run test:coverage
-```
+---
 
 ## Production Deployment
 
-The project includes an automated deployment flow similar to `firstEnglishBook`:
+CI/CD via GitHub Actions on push to `main`. Artifacts use Next.js `standalone` output.
 
-- GitHub Actions automatically builds after changes land on the `main` branch.
-- Build artifacts use Next.js `standalone` output, which is suitable for direct deployment to a cloud server.
-- Actions uploads the deployment package to the Alibaba Cloud server over SSH and runs the remote restart command.
+### GitHub Actions — required secrets and variables
 
-### 1. GitHub Actions Configuration
+Configure in the repository's `production` Environment:
 
-Workflow file: `.github/workflows/deploy-aliyun.yml`
+| Key | Type | Description |
+|-----|------|-------------|
+| `DEPLOY_SSH_PRIVATE_KEY` | Secret | SSH private key for deployment |
+| `DEPLOY_KNOWN_HOSTS` | Secret | `known_hosts` content for target server |
+| `DEPLOY_ENV_FILE` | Secret | Optional `.env.production` written during CI build |
+| `DEPLOY_HOST` | Variable | Server address, e.g. `root@1.2.3.4` |
+| `DEPLOY_PATH` | Variable | Deploy directory, e.g. `/opt/picinterpreter` |
+| `DEPLOY_PORT` | Variable | SSH port, defaults to `22` |
+| `DEPLOY_RESTART_CMD` | Variable | Defaults to `systemctl restart picinterpreter` |
+| `DEPLOY_START_CMD` | Variable | Fallback start command for first deploy |
 
-Configure the following in the GitHub repository's `production` Environment:
+### Server requirements
 
-- Secret `DEPLOY_SSH_PRIVATE_KEY`: private key used for deployment.
-- Secret `DEPLOY_KNOWN_HOSTS`: `known_hosts` content for the target server.
-- Secret `DEPLOY_ENV_FILE`: optional. Written to CI as `.env.production` for environment variables needed at build time. If you do not want to enable the Service Worker yet, include `NEXT_PUBLIC_ENABLE_SERVICE_WORKER=false`.
-- Variable `DEPLOY_HOST`: server address, for example `root@1.2.3.4`.
-- Variable `DEPLOY_PATH`: deployment directory, for example `/opt/picinterpreter`.
-- Variable `DEPLOY_PORT`: optional, defaults to `22`.
-- Variable `DEPLOY_RESTART_CMD`: optional, defaults to `systemctl restart picinterpreter`.
-- Variable `DEPLOY_START_CMD`: optional fallback start command for first-time deployment or restart failure.
+Node.js 20+, write access to the deploy directory, managed by `systemd` or `pm2`.
 
-### 2. Server Requirements
+Deployed artifacts: `.next/standalone` (server.js + node_modules), `.next/static`, `public`, `.env.production` if present.
 
-- Node.js 20+.
-- Write permission for the target directory.
-- The remote service should preferably be managed by `systemd` or `pm2`.
-
-The deployment script uploads these artifacts:
-
-- `server.js` and `node_modules` from `.next/standalone`
-- `.next/static`
-- `public`
-- `.env.production`, if it exists in the CI workspace
-
-Recommended production environment layering:
-
-- Preferred: configure `AI_API_KEY`, `AI_BASE_URL`, and `AI_MODEL` directly in `systemd`, `pm2`, or your container platform.
-- Secondary option: use `.env.production` if the deployment package truly needs to ship it.
-- Avoid: manually placing `.env.local` on the server.
-
-### 3. Manual Deployment
-
-You can also deploy directly from your local machine:
+### Manual deploy
 
 ```bash
 npm run deploy:aliyun -- \
@@ -170,7 +268,7 @@ npm run deploy:aliyun -- \
   --restart "systemctl restart picinterpreter"
 ```
 
-For an initial deployment where the remote service does not exist yet, include a start command:
+For first deploy (service not yet running):
 
 ```bash
 npm run deploy:aliyun -- \
@@ -180,67 +278,45 @@ npm run deploy:aliyun -- \
   --start "pm2 start server.js --name picinterpreter --update-env"
 ```
 
-If your production environment depends on `AI_API_KEY`, `AI_BASE_URL`, and `AI_MODEL`, prefer injecting them through the environment configuration of `systemd` or `pm2` instead of relying only on build-time variables. Provide `.env.production` only when the build or packaging flow explicitly needs it.
+Prefer injecting `AI_API_KEY`, `AI_BASE_URL`, `AI_MODEL` through `systemd`/`pm2` environment config rather than `.env.production`. The Service Worker is disabled by default; old `tuyujia-*` caches are cleared on deploy. Re-enable by setting `NEXT_PUBLIC_ENABLE_SERVICE_WORKER=true` and redeploying.
 
-The repository disables the Service Worker by default. After deployment, it proactively clears old `tuyujia-*` caches and registered Service Workers so browsers do not keep using stale static assets. To re-enable it later, set `NEXT_PUBLIC_ENABLE_SERVICE_WORKER=true` in production and redeploy.
-
-## Data and Storage
-
-- Seed data is located at [public/seed/categories.json](public/seed/categories.json) and [public/seed/pictograms.json](public/seed/pictograms.json).
-- On first load or seed version upgrades, the frontend imports seed data into local `IndexedDB`.
-- User-owned expression records, saved phrases, and some settings are not cleared when seeds are re-imported.
-- The first-use guide state and some UI preferences are stored in `localStorage`.
-
-Database initialization logic: [src/db/index.ts](src/db/index.ts#L1).
-
-## License
-
-This project is released under the GNU General Public License v3.0 or later (`GPL-3.0-or-later`). See [LICENSE](LICENSE).
-
-## Debug and Tools Pages
-
-- `http://localhost:3001/debug`: picture matching validation tool
-- `http://localhost:3001/import`: ARASAAC batch import tool
-
-The import tool searches ARASAAC pictures based on the vocabulary list and exports a new `pictograms.json`, making it easier to update seed data.
+---
 
 ## Project Structure
 
 ```text
 app/
-  api/               Next.js backend APIs
+  api/               Next.js backend API routes
 src/
   components/        UI components and page sections
-  hooks/             Custom hooks for AI, speech, PWA, and more
+  hooks/             Custom hooks (AI, speech, PWA, sync)
   providers/         NLG / TTS provider adapters
-  server/            Server-side AI configuration and call wrappers
+  server/            Server-side AI config and call wrappers
   stores/            Zustand state management
-  db/                Dexie database and seed import
-  utils/             Text matching, resegmentation, placeholders, and other utilities
-  data/              Vocabulary data
+  db/                Dexie schema, migrations, seed import
+  utils/             Text matching, resegmentation, placeholder logic
+  data/              Vocabulary and lexicon data
 public/
-  seed/              Category and picture seed data
+  seed/              Category and pictogram seed JSON
   manifest.json      PWA manifest
   sw.js              Service Worker
 scripts/
-  *.py               Picture and seed data processing scripts
+  *.py               Pictogram and seed data processing scripts
+docs/
+  *.md               Architecture decisions, research notes, PRD
 ```
 
-## Tech Stack
+---
 
-- React 19
-- TypeScript
-- Next.js
-- Tailwind CSS 4
-- Zustand
-- Dexie
-- Vitest
+## Debug Tools
 
-## Current Status
+- `http://localhost:3001/debug` — pictogram matching validator
+- `http://localhost:3001/import` — ARASAAC batch import (searches by vocabulary list, exports updated `pictograms.json`)
 
-This is a prototype project with a mobile-first touch experience. It already includes a complete local expression flow, receiver flow, and optional AI features. AI requests are now centralized through the Next.js backend. If the project continues to evolve, the likely priorities are:
+---
 
-- More complete accessibility and large-text optimization
-- A more stable picture vocabulary and review workflow
-- Clearer deployment and production environment configuration
-- More systematic end-to-end tests
+## License
+
+GNU General Public License v3.0 or later (`GPL-3.0-or-later`). See [LICENSE](LICENSE).
+
+Original repository: https://github.com/lightcoloror/PicInterpreter

--- a/README_cn.md
+++ b/README_cn.md
@@ -1,35 +1,150 @@
-原仓库地址： https://github.com/lightcoloror/PicInterpreter
-# 图语家
+原仓库地址：https://github.com/lightcoloror/PicInterpreter
 
-图语家是一个面向失语症患者和照护者的图片辅助沟通应用。用户可以通过点选图片表达需求，由系统生成候选句子并朗读出来；也支持把照护者输入的文字或语音反向转换为图片序列，帮助患者理解。
+# 图语家 — 面向失语症患者的图片辅助沟通应用
 
-项目当前采用 `Next.js + React 19 + TypeScript` 构建，使用 `Dexie` 管理本地 `IndexedDB` 数据。AI 相关请求统一通过 Next.js 后端 `app/api` 转发，前端不再保存任何 API Key 或 Token。
+图语家是一个开源的 AAC（辅助沟通）应用，面向失语症患者和照护者。患者通过点选图片表达需求，系统生成候选句子并朗读；照护者说话或打字，系统自动转换为图片序列，帮助患者理解。
+
+**这个项目真正的难点：**
+
+1. **把真实口语稳定地转换为图片序列。** 照护者说话时会用方言、省略主语、混乱语序。"妈妈今天肚子有点不舒服想吃点清淡的"需要被正确地转换为图片序列——不只是在输入规范时，在输入混乱时也要对。
+
+2. **用场景和语境让沟通更准。** 同样的一句话，在医院病房、在饭桌边、在康复训练中含义不同。场景信息和对话历史应该影响图片推荐的内容和顺序。
+
+3. **没有网络时仍然能完成基本沟通。** 在乡镇医院、信号不稳的病房、飞机上，基础双向沟通必须可用。离线不是降级模式，而是基准线。
+
+---
+
+## 截图
+
+> 截图即将添加。运行 `npm run dev` 可在 `http://localhost:3001` 看到完整界面。
+>
+> *想贡献截图或演示 GIF？欢迎提 PR，将图片放入 `docs/screenshots/`。*
+
+---
+
+## 快速启动
+
+**不需要数据库，不需要 AI Key。** 核心表达流程和接收流程完全在浏览器本地运行。
+
+```bash
+npm install
+npm run dev
+# 打开 http://localhost:3001
+```
+
+- **没有 AI Key**：句子生成使用离线模板，不影响核心功能。
+- **没有 MySQL**：所有核心流程使用本地 IndexedDB（Dexie），云同步是可选项。
+- **Service Worker 默认关闭**：开发期间不会有缓存问题。
+
+完整环境配置见[环境变量](#环境变量)章节。
+
+---
+
+## 产品原则
+
+这些原则指导每一个技术和 UX 决策：
+
+- **离线优先。** 基础双向沟通必须在没有网络的情况下可用。
+- **AI 辅助，不替代判断。** LLM 辅助重分词可以提升结果，但家属始终有最终决定权。
+- **修正让系统更准。** 每次家属换图或调整顺序，这个信号最终应该反馈到匹配质量中。
+- **患者界面以图标为核心。** 大目标区域，高对比度，患者屏幕上不出现说明性文字。
+- **图片是沟通资产，不是图片文件。** 它们携带含义、顺序和上下文。
+
+---
+
+## 当前优先方向
+
+1. **接收端数据写入** — 接收流程目前没有历史记录写入（[#26](https://github.com/picinterpreter/picinterpreter/issues/26)）
+2. **文本→图片匹配质量** — 同义词盲区、方言口语、复合词（[#8](https://github.com/picinterpreter/picinterpreter/issues/8)、[#15](https://github.com/picinterpreter/picinterpreter/issues/15)）
+3. **双向对话历史作为 LLM 上下文**（[#31](https://github.com/picinterpreter/picinterpreter/issues/31)）
+4. **无障碍与以图标为核心的患者控件**（[#6](https://github.com/picinterpreter/picinterpreter/issues/6)）
+5. **E2E 测试与真机覆盖**（[#33](https://github.com/picinterpreter/picinterpreter/issues/33)）
+
+---
+
+## 如何参与
+
+**不需要懂 AI 才能贡献。** 最需要帮助的工作涵盖匹配逻辑、无障碍、图片数据、测试和 UI。
+
+**适合新贡献者的 issue**（自包含，不需要深入了解领域）：
+
+- [#16 — 语音输入时显示音波动画](https://github.com/picinterpreter/picinterpreter/issues/16)
+- [#6 — 患者界面以图标为核心](https://github.com/picinterpreter/picinterpreter/issues/6)
+
+**按技能分类的贡献方向：**
+
+| 方向 | 相关 Issue / 标签 |
+|------|-----------------|
+| 文本匹配与 NLP | [#8](https://github.com/picinterpreter/picinterpreter/issues/8)、[#15](https://github.com/picinterpreter/picinterpreter/issues/15)，标签：`ai` |
+| 无障碍 | [#6](https://github.com/picinterpreter/picinterpreter/issues/6)，标签：`accessibility` |
+| 图片数据与导入 | [#11](https://github.com/picinterpreter/picinterpreter/issues/11)、[#30](https://github.com/picinterpreter/picinterpreter/issues/30)，标签：`data` |
+| 前端 / UI | [#14](https://github.com/picinterpreter/picinterpreter/issues/14)、[#23](https://github.com/picinterpreter/picinterpreter/issues/23)，标签：`ui` |
+| 测试 | [#33](https://github.com/picinterpreter/picinterpreter/issues/33)，标签：`help wanted` |
+| 后端 / 同步 | [#26](https://github.com/picinterpreter/picinterpreter/issues/26)、[#27](https://github.com/picinterpreter/picinterpreter/issues/27)，标签：`backend` |
+
+较大的改动建议先开 issue 对齐方向，再写代码。
+
+---
 
 ## 核心功能
 
-- 表达模式：按分类浏览图片卡片，拼接表达内容，生成候选句子并语音播报。
-- 接收模式：输入文字或语音，自动匹配为图片序列，支持删改、换图、排序和全屏展示。
-- AI 句子生成：默认可离线使用模板生成；配置后端 AI 环境变量后可切换到在线模型。
-- 语音能力：浏览器原生 TTS 播报，支持试听与语速、语音人配置。
-- 语音输入：支持浏览器 Web Speech API。
-- 本地数据持久化：分类、图片、表达记录、收藏短语和文本转图片结果保存在浏览器本地。
-- 首次使用引导、紧急求助面板、常用语快捷栏、对话历史、分类可见性和高对比度设置。
-- 调试工具页：内置图片匹配验证页和 ARASAAC 导入工具页。
+- **表达模式** — 按分类浏览图片卡片，拼接表达内容，生成候选句子并语音播报。
+- **接收模式** — 输入文字或语音，自动匹配为图片序列，支持删改、换图、排序和全屏展示。
+- **AI 句子生成** — 默认离线模板；配置后端 AI 环境变量后可切换到在线模型。
+- **语音播报** — 浏览器原生 TTS，支持试听与语速、音色配置。
+- **语音输入** — 浏览器 Web Speech API；iOS/Safari 是主要使用路径。
+- **本地数据持久化** — 分类、图片、表达记录、收藏短语保存在 IndexedDB（Dexie）。
+- **可选云同步** — 表达记录和收藏短语通过 outbox 模式同步到 MySQL。
+- 首次使用引导、紧急求助面板、常用语快捷栏、对话历史、分类可见性设置、高对比度模式。
+- **调试工具** — `/debug` 图片匹配验证页，`/import` ARASAAC 批量导入页。
+
+---
+
+## 架构简介
+
+应用以离线优先为核心设计：Dexie（IndexedDB）是主存储，MySQL 是可选的云同步。
+
+```
+表达流程：   分类浏览 → 图片选择 → NLG 生成句子 → TTS 播报
+接收流程：   语音/文字输入 → 分词 → 图片匹配 → 家属审核 → 全屏展示
+数据层：     Dexie（本地，始终可用）← → MySQL via Prisma（可选，同步）
+AI 层：      Next.js API 路由代理到任意 OpenAI-compatible LLM（可选）
+```
+
+**架构文档：**
+- [决策索引 — 已确认决策与待定问题](docs/decision-index.md)
+- [架构评审与关键决策](docs/ARCHITECTURE_REVIEW.md)
+- [ADR-001：接收端数据模型](docs/ADR-001-receiver-data-model.md)
+- [ASR pipeline 调研](docs/ASR_PIPELINE_RESEARCH.md)
+- [产品需求文档](docs/prd.md)
+
+---
+
+## 技术栈
+
+- React 19 + TypeScript
+- Next.js（App Router + Route Handlers）
+- Tailwind CSS 4
+- Zustand（状态管理）
+- Dexie（IndexedDB）
+- Prisma + MySQL（可选同步）
+- Vitest（单元测试）
+
+---
 
 ## 运行环境
 
-- Node.js 18+，当前项目在 `Node 24` 环境下开发。
-- npm
-
-安装依赖：
+Node.js 18+，当前项目在 Node 24 环境下开发。
 
 ```bash
 npm install
 ```
 
+---
+
 ## 环境变量
 
-复制 `.env.example` 为 `.env.local`，按需填写：
+复制 `.env.example` 为 `.env.local`：
 
 ```env
 DATABASE_URL=mysql://root:password@127.0.0.1:3306/picinterpreter
@@ -40,125 +155,111 @@ OPENSYMBOLS_SECRET=
 NEXT_PUBLIC_ENABLE_SERVICE_WORKER=false
 ```
 
-- `DATABASE_URL`：MySQL 连接串，供 Prisma 7 驱动适配器使用。
-- `AI_API_KEY`：服务端调用上游 LLM 的密钥，必填。
-- `AI_BASE_URL`：OpenAI-compatible 接口地址，默认 `https://api.openai.com/v1`。
-- `AI_MODEL`：默认模型名，默认 `gpt-4o-mini`。
-- `OPENSYMBOLS_SECRET`：可选。配置后，运行时缺图补图会在 ARASAAC 未命中时继续查询 OpenSymbols。该值只在服务端读取。
-- `NEXT_PUBLIC_ENABLE_SERVICE_WORKER`：是否启用前端 Service Worker，默认 `false`。仅在显式设置为 `true` 时启用。
+| 变量 | 是否必填 | 说明 |
+|------|---------|------|
+| `DATABASE_URL` | 可选 | MySQL 连接串。不填则完全本地运行。 |
+| `AI_API_KEY` | 可选 | LLM API 密钥。不填则句子生成使用离线模板。 |
+| `AI_BASE_URL` | 可选 | OpenAI-compatible 接口地址。默认 `https://api.openai.com/v1`。 |
+| `AI_MODEL` | 可选 | 模型名称。默认 `gpt-4o-mini`。 |
+| `OPENSYMBOLS_SECRET` | 可选 | ARASAAC 未命中时查询 OpenSymbols。仅服务端读取。 |
+| `NEXT_PUBLIC_ENABLE_SERVICE_WORKER` | 可选 | 是否启用 Service Worker。默认 `false`。 |
 
-其中 `NEXT_PUBLIC_ENABLE_SERVICE_WORKER` 会在构建时注入前端，其余变量仅在 Next.js 服务端读取。
+`NEXT_PUBLIC_ENABLE_SERVICE_WORKER` 在构建时注入前端，其余变量仅在服务端读取。
 
-建议按下面的约定使用：
+**使用约定：**
+- 本地开发：`.env.local`
+- CI：只在构建阶段确实需要时写入 `.env.production`
+- 生产运行：优先通过 `systemd`、`pm2` 或容器平台注入环境变量，不在服务器长期保留 `.env.local`（否则可能静默覆盖 `.env.production`）
 
-- 本地开发：使用 `.env.local`。
-- 仓库示例：保留 `.env.example`，不要提交真实密钥。
-- CI 构建：只有在构建阶段确实需要时，才由 GitHub Actions 临时写入 `.env.production`。
-- 生产运行：优先通过 `systemd`、`pm2` 或容器平台直接注入环境变量，不依赖服务器上的环境文件。
-
-原因：
-
-- 这个项目本地开发约定已经是 `.env.local`。
-- Next.js 在 `production` 环境下会优先读取 `process.env`，然后读取 `.env.production.local`、`.env.local`、`.env.production`、`.env`。这意味着如果服务器上同时存在 `.env.local` 和 `.env.production`，前者会覆盖后者。
-- 因此不建议在服务器长期保留 `.env.local`，否则很容易出现“CI 传了 `.env.production`，但运行时实际没生效”的问题。
-
-## 本地开发
-
-```bash
-npm run dev
-```
-
-默认端口：`http://localhost:3001`
-
-## AI 后端接口
-
-当前由 Next.js Route Handlers 提供：
-
-- `GET /api/ai/health`：读取后端 AI 配置状态。
-- `POST /api/ai/sentences`：生成候选句。
-- `POST /api/ai/resegment`：AI 辅助重分词。
-- `POST /api/pictograms/search`：运行时缺图补图；服务端查询专用 AAC 图库，前端写入本地 IndexedDB。
-- `POST /api/client/bootstrap`：注册/恢复匿名设备身份，并设置 HttpOnly 设备 Cookie。
-- `POST /api/sync/push`：把本地 `expressions` / `saved_phrases` 变更推送到服务端 MySQL。
-- `GET /api/sync/pull`：按增量游标拉取服务端变更并回放到本地 Dexie。
-
-前端只调用这些内部接口；实际的 `API Key`、`Base URL`、`Model` 均由服务端环境变量控制。
-
-## MySQL 同步架构
-
-- 前端继续用 `Dexie` 作为本地主存储，保证离线体验。
-- 服务端通过 `Prisma 6 + mysql` 连接 MySQL 8。
-- 当前已上云的数据仅包括 `expressions` 与 `saved_phrases`。
-- 首次打开会自动 bootstrap 一个匿名设备身份；未来接入正式登录后，可把匿名用户数据合并到账号用户。
-- 本地新增了 `syncOutbox` / `syncState` 两张 Dexie 表，用于后台同步与增量游标管理。
-
-首次初始化数据库可用：
-
-```bash
-npm run prisma:generate
-npm run prisma:push
-```
+---
 
 ## 常用命令
 
 ```bash
-npm run dev
-npm run build
-npm run start
-npm run prisma:generate
-npm run prisma:push
-npm run deploy:aliyun -- --host root@1.2.3.4 --path /opt/picinterpreter
-npm run lint
-npm run test
-npm run test:watch
-npm run test:coverage
+npm run dev              # 启动开发服务器，http://localhost:3001
+npm run build            # 生产构建
+npm run start            # 本地启动生产构建
+npm run lint             # ESLint
+npm run test             # Vitest（运行一次）
+npm run test:watch       # Vitest（监听模式）
+npm run test:coverage    # Vitest 覆盖率报告
+npm run prisma:generate  # 生成 Prisma client
+npm run prisma:push      # 推送 schema 到 MySQL（首次初始化）
 ```
 
-## 生产部署（参考 firstEnglishBook 自动化流程）
+---
 
-项目已提供一套和 `firstEnglishBook` 类似的自动化部署链路：
+## AI 后端接口
 
-- GitHub Actions 在 `main` 分支变更后自动构建。
-- 构建产物使用 Next.js `standalone` 输出，适合直接部署到云服务器。
-- Actions 通过 SSH 把部署包上传到阿里云服务器，并执行远程重启命令。
+由 Next.js Route Handlers 提供：
 
-### 1. GitHub Actions 配置
+| 接口 | 方法 | 说明 |
+|------|------|------|
+| `/api/ai/health` | GET | 读取后端 AI 配置状态 |
+| `/api/ai/sentences` | POST | 生成候选句子 |
+| `/api/ai/resegment` | POST | AI 辅助重分词 |
+| `/api/pictograms/search` | POST | 运行时缺图补图（ARASAAC / OpenSymbols） |
+| `/api/client/bootstrap` | POST | 注册/恢复匿名设备身份 |
+| `/api/sync/push` | POST | 推送本地变更到 MySQL |
+| `/api/sync/pull` | GET | 按增量游标拉取服务端变更 |
 
-工作流文件：`.github/workflows/deploy-aliyun.yml`
+前端只调用这些内部接口，API Key 不会暴露给客户端。
 
-需要在 GitHub 仓库的 `production` Environment 中配置：
+---
 
-- Secret `DEPLOY_SSH_PRIVATE_KEY`：部署用私钥。
-- Secret `DEPLOY_KNOWN_HOSTS`：目标服务器的 `known_hosts` 内容。
-- Secret `DEPLOY_ENV_FILE`：可选。写入 CI 的 `.env.production`，用于构建期需要的环境变量。若暂时不希望启用 Service Worker，请在其中加入 `NEXT_PUBLIC_ENABLE_SERVICE_WORKER=false`。
-- Variable `DEPLOY_HOST`：服务器地址，例如 `root@1.2.3.4`。
-- Variable `DEPLOY_PATH`：部署目录，例如 `/opt/picinterpreter`。
-- Variable `DEPLOY_PORT`：可选，默认 `22`。
-- Variable `DEPLOY_RESTART_CMD`：可选，默认 `systemctl restart picinterpreter`。
-- Variable `DEPLOY_START_CMD`：可选。首发部署或重启失败时的兜底启动命令。
+## 数据与存储
 
-### 2. 服务器要求
+- 种子数据：[`public/seed/categories.json`](public/seed/categories.json) 和 [`public/seed/pictograms.json`](public/seed/pictograms.json)
+- 首次加载或种子版本升级时，前端自动导入到 IndexedDB
+- 用户表达记录、收藏短语和部分设置不会因种子重导而清空
+- 首次使用引导状态和部分 UI 配置保存在 `localStorage`
+- 数据库初始化逻辑：[`src/db/index.ts`](src/db/index.ts)
 
-- Node.js 20+。
-- 目标目录具备写权限。
-- 远程服务建议通过 `systemd` 或 `pm2` 托管。
+---
 
-部署脚本会上传这些产物：
+## MySQL 同步（可选）
 
-- `server.js` 与 `node_modules`（来自 `.next/standalone`）
-- `.next/static`
-- `public`
-- `.env.production`（如果 CI 工作区中存在）
+- Dexie 始终是本地主存储，离线体验不受影响
+- MySQL 8 通过 Prisma 用于跨设备同步
+- 已同步表：`expressions`、`saved_phrases`
+- 首次打开自动 bootstrap 匿名设备身份（未来接入登录后可合并到账号）
+- Dexie 新增 `syncOutbox` / `syncState` 表用于后台同步与增量游标管理
 
-生产环境建议这样分层：
+首次初始化数据库：
 
-- 首选：在 `systemd`/`pm2`/容器平台中直接配置 `AI_API_KEY`、`AI_BASE_URL`、`AI_MODEL`。
-- 次选：如果确实需要随部署包下发，再使用 `.env.production`。
-- 避免：在服务器手工放置 `.env.local`。
+```bash
+npm run prisma:generate
+npm run prisma:push
+```
 
-### 3. 手动部署
+---
 
-也可以在本地直接执行：
+## 生产部署
+
+GitHub Actions 在 `main` 分支变更后自动构建，使用 Next.js `standalone` 输出。
+
+### GitHub Actions — 需要配置的 Secrets 和 Variables
+
+在仓库的 `production` Environment 中配置：
+
+| 键 | 类型 | 说明 |
+|----|------|------|
+| `DEPLOY_SSH_PRIVATE_KEY` | Secret | 部署用 SSH 私钥 |
+| `DEPLOY_KNOWN_HOSTS` | Secret | 目标服务器的 `known_hosts` 内容 |
+| `DEPLOY_ENV_FILE` | Secret | 可选，写入 CI 的 `.env.production` |
+| `DEPLOY_HOST` | Variable | 服务器地址，如 `root@1.2.3.4` |
+| `DEPLOY_PATH` | Variable | 部署目录，如 `/opt/picinterpreter` |
+| `DEPLOY_PORT` | Variable | SSH 端口，默认 `22` |
+| `DEPLOY_RESTART_CMD` | Variable | 默认 `systemctl restart picinterpreter` |
+| `DEPLOY_START_CMD` | Variable | 首发部署或重启失败时的兜底启动命令 |
+
+### 服务器要求
+
+Node.js 20+，目标目录具备写权限，建议通过 `systemd` 或 `pm2` 托管。
+
+部署产物：`.next/standalone`（server.js + node_modules）、`.next/static`、`public`、`.env.production`（如存在）。
+
+### 手动部署
 
 ```bash
 npm run deploy:aliyun -- \
@@ -167,7 +268,7 @@ npm run deploy:aliyun -- \
   --restart "systemctl restart picinterpreter"
 ```
 
-首发部署如果远程服务还没创建，可以附带启动命令，例如：
+首发部署（远程服务还没创建）：
 
 ```bash
 npm run deploy:aliyun -- \
@@ -177,67 +278,43 @@ npm run deploy:aliyun -- \
   --start "pm2 start server.js --name picinterpreter --update-env"
 ```
 
-如果你的生产环境依赖 `AI_API_KEY`、`AI_BASE_URL`、`AI_MODEL`，建议优先通过 `systemd`/`pm2` 的环境配置注入，而不是只依赖构建期变量。只有在构建期或打包部署链路明确需要时，再额外提供 `.env.production`。
+建议通过 `systemd`/`pm2` 环境配置注入 `AI_API_KEY`、`AI_BASE_URL`、`AI_MODEL`，不依赖 `.env.production`。Service Worker 默认关闭；部署后会主动清理旧 `tuyujia-*` 缓存。重新启用请将 `NEXT_PUBLIC_ENABLE_SERVICE_WORKER=true` 后重新部署。
 
-当前仓库默认关闭 Service Worker，部署后会主动清理旧的 `tuyujia-*` 缓存和已注册的 Service Worker，避免浏览器继续使用旧版本静态资源。以后如果需要重新启用，只需在生产环境中把 `NEXT_PUBLIC_ENABLE_SERVICE_WORKER=true` 后重新部署即可。
-
-## 数据与存储
-
-- 种子数据位于 [public/seed/categories.json](public/seed/categories.json) 和 [public/seed/pictograms.json](public/seed/pictograms.json)。
-- 首次加载或种子版本升级时，前端会将种子数据导入本地 `IndexedDB`。
-- 用户自己的表达记录、收藏短语和部分设置不会因种子重导而清空。
-- 首次使用引导状态和部分 UI 配置保存在 `localStorage`。
-
-数据库初始化逻辑见 [src/db/index.ts](src/db/index.ts#L1)。
-
-## License
-
-本项目采用 GNU General Public License v3.0 or later（`GPL-3.0-or-later`）发布。详见 [LICENSE](LICENSE)。
-
-## 调试与工具页
-
-- `http://localhost:3001/debug`：图片匹配验证工具
-- `http://localhost:3001/import`：ARASAAC 批量导入工具
-
-其中导入工具会根据词库搜索 ARASAAC 图片并导出新的 `pictograms.json`，便于更新种子数据。
+---
 
 ## 项目结构
 
 ```text
 app/
-  api/               Next.js 后端接口
+  api/               Next.js 后端 API 路由
 src/
   components/        UI 组件与页面片段
-  hooks/             AI、语音、PWA 等自定义 Hook
+  hooks/             AI、语音、PWA、同步等自定义 Hook
   providers/         NLG / TTS 提供者适配层
   server/            服务端 AI 配置与调用封装
   stores/            Zustand 状态管理
-  db/                Dexie 数据库与种子导入
+  db/                Dexie schema、迁移与种子导入
   utils/             文本匹配、重分词、占位图等工具函数
-  data/              词库数据
+  data/              词库与词典数据
 public/
-  seed/              分类与图片种子数据
+  seed/              分类与图片种子 JSON
   manifest.json      PWA 清单
   sw.js              Service Worker
 scripts/
   *.py               图片与种子数据整理脚本
+docs/
+  *.md               架构决策、调研笔记、产品需求
 ```
 
-## 技术栈
+---
 
-- React 19
-- TypeScript
-- Next.js
-- Tailwind CSS 4
-- Zustand
-- Dexie
-- Vitest
+## 调试与工具页
 
-## 当前状态
+- `http://localhost:3001/debug` — 图片匹配验证工具
+- `http://localhost:3001/import` — ARASAAC 批量导入工具（根据词库搜索并导出新的 `pictograms.json`）
 
-这是一个以移动端触控体验为优先的原型项目，已经具备完整的本地表达流程、接收流程和可选 AI 能力。当前版本已将 AI 请求收口到 Next.js 后端，后续如果继续演进，优先方向通常会是：
+---
 
-- 更完整的无障碍与大字体优化
-- 更稳定的图片词库与审核流程
-- 更清晰的部署方式与生产环境配置
-- 更系统的端到端测试
+## License
+
+本项目采用 GNU General Public License v3.0 or later（`GPL-3.0-or-later`）发布。详见 [LICENSE](LICENSE)。

--- a/docs/ADR-001-receiver-data-model.md
+++ b/docs/ADR-001-receiver-data-model.md
@@ -1,0 +1,132 @@
+# ADR-001: 接收端数据模型
+
+**状态：** 已采纳  
+**日期：** 2026-04-29  
+**参与者：** Claude + Codex + 产品负责人
+
+---
+
+## 背景
+
+接收端（Receiver）流程目前完成了"输入→分词→匹配→编辑→全屏展示"的完整链路，
+但没有将任何数据写入 IndexedDB 或服务端数据库。这导致：
+
+1. 历史对话记录里缺少接收端事件（只有 `direction='express'` 记录）
+2. 家属的换图/删除/排序修正动作全部丢失，无法驱动后续的修正记忆和词典学习
+3. 无法为 LLM 提供接收端上下文（用于 NLG 和 resegment 质量提升）
+
+相关 issue：[#26](https://github.com/picinterpreter/picinterpreter/issues/26)
+
+---
+
+## 决策
+
+### 1. 主记录：扩展现有 `Expression`，不新建并行类型
+
+仓库中已有 `Expression`（Dexie）/ `ExpressionRecord`（Prisma）作为对话事件的统一载体，
+且已预留 `direction: 'receive'` 值。在此基础上扩展接收端专用字段，
+避免引入第二套沟通记录主表（否则会造成双份同步逻辑、双份迁移成本）。
+
+**新增字段（均可选，向后兼容）：**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `normalizedText` | `string?` | 方言/口语归一化后的文本，供调试和未来 NLG 上下文使用 |
+| `initialPictogramIds` | `string[]?` | 识别+匹配完成时的初始图片 ID 序列（修正前快照） |
+| `initialPictogramLabels` | `string[]?` | 对应初始标签（冗余存储，防图库变更） |
+| `wasManuallyCorrected` | `boolean?` | 家属是否进行过任何手动修正 |
+| `recordStatus` | `'draft' \| 'confirmed'?` | 记录生命周期（见两阶段写入） |
+
+### 2. 两阶段写入生命周期
+
+接收端一条记录经历两个时间点：
+
+```
+识别+匹配完成
+  → 立即写入 draft
+      initialPictogramIds / Labels 快照此刻的自动匹配结果
+      recordStatus = 'draft'
+      【不加入同步 outbox】
+
+家属编辑 → 点击"展示给患者" → 全屏展示 → 确认完成
+  → 覆盖同一条记录
+      pictogramIds / Labels 更新为最终序列
+      wasManuallyCorrected = 是否有过修正
+      recordStatus = 'confirmed'
+      【此时加入同步 outbox，触发云端同步】
+
+若家属按"重新输入"（未经展示）
+  → 删除该 draft 记录（不计入历史）
+```
+
+**设计理由：**
+- Draft 不同步，避免污染其他设备的历史视图
+- Confirmed 才同步，保证历史记录都是"已展示给患者"的有效事件
+- `initialPictogramIds` 与最终 `pictogramIds` 的差集即为修正内容，可驱动词典增量学习
+
+### 3. 修正动作日志：新建 `ReceiverCorrection`（Dexie-only）
+
+每次家属在 review 阶段执行编辑操作，写一条修正日志。
+此表为本地专用，**不加入同步 outbox，不上传服务端**（现阶段）。
+
+```ts
+interface ReceiverCorrection {
+  id: string
+  expressionId: string            // 关联 draft/confirmed Expression
+  action: 'replace_pictogram'
+        | 'remove_pictogram'
+        | 'reorder_pictograms'
+        | 'merge_tokens'
+        | 'rewrite_text'
+  tokenBefore?: string[]          // 修正前的 token 序列
+  tokenAfter?: string[]           // 修正后的 token 序列
+  pictogramIdsBefore?: string[]   // 修正前的图片 ID 序列
+  pictogramIdsAfter?: string[]    // 修正后的图片 ID 序列
+  createdAt: number
+}
+```
+
+**字段设计理由（为什么不用 `before/after: unknown`）：**
+- 具体字段让词典学习脚本可以直接统计"哪些 token 总被换成哪张图"
+- 避免后续做词典增量时反序列化 unknown JSON 的脏逻辑
+
+**修正记忆入口（本 ADR 不实现，预留路径）：**
+```
+ReceiverCorrection(replace_pictogram)
+  → 统计 tokenBefore[n] → pictogramIdsAfter[n] 的映射频次
+  → 频次 ≥ 阈值 → 写入 lexicon-overrides.json
+  → 下次匹配时优先命中
+```
+
+### 4. 同步层影响
+
+- `SyncEntityType` 不需要变更（`'expression'` 已覆盖）
+- `SyncOutboxItem.payload` 类型为 `Expression | SavedPhrase`，新字段属于 `Expression` 扩展，无需修改 sync 接口
+- Prisma `ExpressionRecord` 新增对应可空列（见实现部分）
+- `ReceiverCorrection` 不纳入同步，Prisma 不建表
+
+---
+
+## 实现范围
+
+本 ADR 对应的代码改动：
+
+| 文件 | 改动 |
+|------|------|
+| `src/types/index.ts` | `Expression` 扩展 5 个字段；新增 `ReceiverCorrection` 接口 |
+| `src/db/index.ts` | Dexie v5：新增 `receiverCorrections` 表 |
+| `prisma/schema.prisma` | `ExpressionRecord` 新增 5 个可空列 |
+| `src/repositories/expressions-repository.ts` | 新增 `createDraftReceiveExpression`、`confirmReceiveExpression`、`deleteDraftExpression` |
+| `src/repositories/receiver-corrections-repository.ts` | 新文件，`logCorrection` |
+| `src/components/ReceiverPanel/ReceiverPanel.tsx` | 两阶段写入 + 修正日志调用 |
+
+---
+
+## 备选方案（已否决）
+
+**方案 B：新建 `ReceiverTranscript` 独立主表**  
+否决原因：造成双份概念和双份同步逻辑，`Expression.direction='receive'` 已足够区分方向。
+
+**方案 C：只在 confirmed 时写一次**  
+否决原因：`initialPictogramIds` 快照需要在修正前捕获；若家属长时间编辑后 crash，
+则 confirmed 永远不会被写入，丢失本次对话事件。

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -1,0 +1,480 @@
+# 图语家（picinterpreter）架构与技术选型评审
+
+> 评审时间：2026-04-28
+> 评审视角：产品负责人 + 外部架构师
+> 方法：盘点项目实际代码 → 检索同领域开源参考方案与 2026 年业界主流实践 → 逐项给出意图、证据与评价
+
+每一节都按以下四段式展开：
+
+- **现状（Current）**：项目实际选了什么。
+- **意图（Intent）**：从代码、注释、README 推断的决策动机。
+- **证据（Evidence）**：同领域开源参考方案、当下业界主流观点。
+- **评价（Assessment）**：是否合理，风险与改进建议。
+
+---
+
+## 0. 总体定位
+
+图语家是一款面向**失语症患者及其照护者**的 AAC（Augmentative and Alternative Communication，增强与替代沟通）Web 应用。核心场景：
+
+- **表达端**：患者用图片序列拼出意图 → AI 生成候选句 → TTS 播报。
+- **接收端**：照护者输入文字 / 语音 → 自动匹配图片序列 → 全屏展示给患者看。
+
+这类产品在国际上有一系列长期开源参考方案，最值得对标的两个是 **AsTeRICS Grid** 和 **Cboard**——同样是 web-based、offline-capable、symbol-based、支持 TTS 的 AAC 应用 ([Cboard GitHub](https://github.com/cboard-org/cboard), [AsTeRICS Grid 论文](https://link.springer.com/chapter/10.1007/978-3-031-62849-8_16))。下文很多决策都会拿这两个项目作为对照。
+
+---
+
+## 1. 整体架构哲学：Local-First + 可选云同步
+
+### 现状
+
+- 浏览器内 IndexedDB（Dexie）作为**主存储**。
+- 可选连接到 Next.js 后端，把 `expressions` / `saved_phrases` 同步到 MySQL。
+- 用户首次进入时分配匿名 deviceId（localStorage 存 `installId`，server 存 hash），后续可升级为正式登录账号。
+
+### 意图
+
+- 失语症患者的沟通工具必须**离线可用**——医院、户外、网络不稳定都是常见场景。
+- 患者的表达数据天然敏感（医疗、情绪），不强制上云能降低隐私顾虑。
+- 但跨设备同步又是真实需求（家属手机 + 平板 + 照护者手机）。
+
+### 证据
+
+> "AsTeRICS Grid 的架构有三大优势：跨平台 web 可访问、offline-capable、去中心化设计——服务器仅在初次访问和数据同步时被需要。" ([AsTeRICS Grid 论文](https://link.springer.com/chapter/10.1007/978-3-031-62849-8_16))
+
+> "2026 年的标准是：主读写在设备上瞬时完成（SQLite/IndexedDB/CRDT），背景同步异步推送到服务端。" ([Local-First Software Development Patterns for 2026](https://tech-champion.com/software-engineering/the-local-first-manifesto-why-the-cloud-is-losing-its-luster-in-2026/))
+
+行业讨论已经从"要不要做 local-first"变成"如何正确做"。
+
+### 评价
+
+✅ **方向完全正确**。这是 AAC 这类工具最合适的架构哲学，与 AsTeRICS Grid 殊途同归。
+
+⚠️ **一个潜在隐患**：当前同步只覆盖了 `expressions` 和 `saved_phrases`，没有同步 `pictograms`（图片库）和 `categories`（分类）。如果家属在 A 设备上传/补全了图片，B 设备的患者看不到——这违背了"跨设备一致体验"的承诺。建议把 `pictograms` 的用户级修改也纳入同步范围（种子数据除外）。
+
+---
+
+## 2. 前端框架：Next.js 15 + React 19 + TypeScript
+
+### 现状
+
+- App Router (`app/`)。
+- Server Components + Route Handlers（`/api/*`）混合架构。
+- Standalone build 输出，部署到阿里云。
+
+### 意图
+
+- 服务端 Route Handlers 承载 AI 调用和同步 API，避免在前端暴露 API Key。
+- App Router + RSC 是 Next.js 当前唯一官方推荐路线。
+
+### 证据
+
+> "Next.js 15 提供了对 React 19 的支持，App Router 使用 React 19 RC。" ([Next.js 15 发布说明](https://nextjs.org/blog/next-15))
+
+参考 AsTeRICS Grid 用的是更轻量的纯静态 + GitHub Pages + Service Worker 方案 ([AsTeRICS Grid 论文](https://link.springer.com/chapter/10.1007/978-3-031-62849-8_16))；Cboard 用的是 CRA / React 单页架构 ([Cboard GitHub](https://github.com/cboard-org/cboard))。
+
+### 评价
+
+✅ **选 Next.js 而非纯 SPA 是合理的**——后端 API（AI 代理、同步、登录）已经存在，Next.js 让前后端在同一个仓库、同一个部署单元里维护，比拆分两个项目轻得多。
+
+⚠️ **代价是部署复杂度**。AsTeRICS Grid 用 GitHub Pages 静态托管 + CouchDB 同步，几乎零运维成本；图语家需要 Node.js 进程 + MySQL + GitHub Actions 部署流水线。对于由"非全职团队"维护的 OSS 项目而言，这是隐性的长期负担。
+
+🤔 **可选方向**：如果以后想降低部署门槛，把"AI 代理 + 同步"拆出来做成独立的微服务（FastAPI / Hono），前端回退到纯静态 + Cloudflare Pages，整体维护成本会显著下降。但这是"项目成熟度变高之后"才值得做的重构。
+
+---
+
+## 3. UI 体系：Tailwind CSS 4 + Radix UI
+
+### 现状
+
+- Tailwind CSS 4（最新主版本，配置在 `postcss.config.mjs` 里）。
+- Radix UI 提供 Dialog / Tabs / Tooltip 三个无样式底层组件。
+- 自研图标系统 `LineIcon`（线性 SVG）。
+- 设计风格"靠近 Apple"（来自 `AGENTS.md`）。
+
+### 意图
+
+- Radix 解决"无障碍 + 键盘焦点 + 焦点陷阱"等繁琐细节，但不强加视觉。
+- 图标统一线性风格，避免乱用 emoji——这条规则在 `AGENTS.md` 中明确写出。
+
+### 证据
+
+WCAG 2.2 在 2026 年依然是事实标准，重点新增了 **触控目标尺寸（最少 24×24px，最佳 44×44px）、焦点可见性、对比度** 等针对运动障碍 / 低视力 / 认知障碍人群的准则 ([WCAG 2.2 检查清单](https://www.levelaccess.com/blog/wcag-2-2-aa-summary-and-checklist-for-website-owners/))。
+
+`AGENTS.md` 里"触控目标不小于 44px"已经超过了 WCAG 2.2 AA 的下限。
+
+### 评价
+
+✅ **AGENTS.md 是这个项目最被低估的资产**。它不是普通 README，而是一份**面向 AAC 失语症患者的 UI/UX 章程**——明文规定患者主流程不放小字、按钮短动词、紧急求助零学习成本、44px 触控目标。这正好对应 WCAG 2.2 中的认知 / 运动障碍准则。
+
+⚠️ **目前缺一份"对照清单"** 把 AGENTS.md 里的规则映射到 WCAG 2.2 success criteria 上，便于后续做合规审计。这个工作量不大（约半天），但对 AAC 类产品很关键。
+
+---
+
+## 4. 本地存储：Dexie 4 (IndexedDB)
+
+### 现状
+
+- 7 张表：`categories`、`pictograms`、`expressions`、`savedPhrases`、`textToImageResults`、`syncOutbox`、`syncState`。
+- 已经迭代到 schema v4，每次升级保留用户数据。
+- 种子数据通过 `SEED_VERSION` 控制重导入，但绕开用户表。
+
+### 意图
+
+- 失语症患者依赖图片库——必须离线可用。
+- IndexedDB 比 localStorage 容量大（上百 MB vs 5MB），适合存图片元数据 + 候选句历史。
+- Dexie 比裸 IndexedDB API 友好得多。
+
+### 证据
+
+Dexie 是当前 web 端 IndexedDB 的事实标准封装；AsTeRICS Grid 也直接用 IndexedDB（通过 PouchDB）+ 可选 CouchDB 同步 ([AsTeRICS Grid 论文](https://link.springer.com/chapter/10.1007/978-3-031-62849-8_16))。
+
+> "IndexedDB/SQLite + 队列式或 CRDT 模型" 是 2026 年 offline-first 应用的标准存储选型 ([Local-First Software 2026](https://tech-champion.com/software-engineering/the-local-first-manifesto-why-the-cloud-is-losing-its-luster-in-2026/))。
+
+### 评价
+
+✅ **选型完全主流**，schema 版本管理也做得很规范（v1→v2→v3→v4 全部保留迁移逻辑）。
+
+⚠️ **图片二进制本身没存进 IndexedDB**——目前依赖 `imageUrl`（或 data URL placeholder）。一旦 ARASAAC / OpenSymbols 服务不可用，离线时图片就显示不出来。建议引入"按使用频率缓存最近 N 张图片二进制到 IndexedDB"的策略，或者改用 Service Worker 的 Cache API 缓存图片资源。
+
+🤔 **未来方向**：如果将来要支持 50K+ 图片量级（接近完整 ARASAAC 库），IndexedDB 索引性能会成为瓶颈，那时考虑 [SQLite WASM (OPFS)](https://sqlite.org/wasm/doc/trunk/persistence.md) 是更稳健的选择，但目前完全不必折腾。
+
+---
+
+## 5. 后端 + ORM：Next.js Route Handlers + Prisma 6 + MySQL 8
+
+### 现状
+
+- Route Handlers 在 `app/api/*` 下，包括 `ai/sentences`、`ai/resegment`、`pictograms/search`、`client/bootstrap`、`sync/push`、`sync/pull`、`auth/*`。
+- Prisma 6 + MySQL 8。
+- Schema 包含 `User` / `Device` / `AuthAccount` / `PasswordCredential` / `UserSession` / `ExpressionRecord` / `SavedPhraseRecord` / `SyncChange`。
+
+### 意图
+
+- MySQL 是阿里云上最便宜稳定的托管 RDB；Prisma 提供类型安全的 ORM。
+- 把"匿名设备"和"实名用户"拆成两层（Device 关联到 User，初始 isAnonymous=true，登录后可合并），是教科书级别的好设计。
+
+### 证据
+
+Prisma 6 在 2026 年依然是 TypeScript 项目最主流的 ORM 之一，特别是配合 Next.js 时。
+
+### 评价
+
+✅ **schema 设计有水准**。亮点：
+- `SyncChange` 单调自增 id 给客户端做增量游标，比时间戳同步更可靠（避免时钟漂移）。
+- `ExpressionRecord.version` 字段做 optimistic locking。
+- `UserSession.tokenHash` 而不是明文 token。
+- `PasswordCredential` 拆出来做 1:1，避免 User 表臃肿。
+
+⚠️ **MySQL 选型可商榷**。考虑到：
+1. 同步流量主要是 `JSON` 列（`pictogramIds`、`pictogramLabels` 等数组）。
+2. 用户量不大但数据天然多设备。
+3. 后续可能需要全文搜索患者的表达历史。
+
+PostgreSQL 在 JSON 操作（`jsonb`）、全文搜索、扩展生态上都比 MySQL 更适合这个场景。**但已经选了 MySQL 就不必为换而换**——只在以后真的撞到这些限制时再考虑。
+
+⚠️ **`ensureDatabaseSchema()`** 每次 API 请求都跑一次会浪费资源。看实现是否有 cache，若没有应改成"应用启动一次 + 启动时 push migrations"。
+
+---
+
+## 6. 同步策略：增量 changeId + Optimistic Version + LWW
+
+### 现状
+
+读 `src/services/sync-service.ts` 和 `src/server/sync/service.ts`：
+
+- 客户端：本地写入时同时往 `syncOutbox` 排队 mutation，后台批量 push。
+- 服务端：每个 push 比较 `mutation.baseVersion` 和数据库 `existing.version`，不同就标记 `conflicted=true`，但**仍然 LWW（用 mutation 覆盖）**。
+- 服务端给每个变更分配单调递增 `SyncChange.id`，客户端用 `lastPulledChangeId` 做增量 pull。
+- 触发：`online` 事件、`visibilitychange` 切回前台、显式 `scheduleSync()`。
+
+### 意图
+
+- 简单可靠：避免 CRDT 的复杂度，对单用户多设备场景已经够用。
+- 单调 changeId 比时间戳稳健（不依赖客户端时钟）。
+
+### 证据
+
+> "Last-Write-Wins 简单易实现但实操危险——会静默丢失数据。" ([System Design Pattern: From Chaos to Consistency](https://medium.com/@priyasrivastava18official/system-design-pattern-from-chaos-to-consistency-the-art-of-conflict-resolution-in-distributed-9d631028bdb4))
+
+> "Apple 的 Notes 应用用 CRDT 在 iPhone/iPad/Mac 间同步离线编辑——CRDT 自动合并并发更新而不丢失数据。" ([CRDTs Explained: Conflict-Free Replicated Data Types](https://www.designgurus.io/blog/crdts-for-eventual-consistency))
+
+但 CRDT 的复杂度并非每个项目都值得：
+
+> "CRDT 的级联复杂度——CRDT 单独不够。"（[The Cascading Complexity of Offline-First Sync](https://dev.to/biozal/the-cascading-complexity-of-offline-first-sync-why-crdts-alone-arent-enough-2gf)）
+
+### 评价
+
+✅ **当前设计对图语家场景是合理的**——患者多数时候是单设备主用户，并发写冲突极少。LWW 的"风险"在于**协作编辑场景**，不在"同一用户多终端"。
+
+⚠️ **风险点：`conflicted=true` 没有任何用户层面表现**。代码里只是标了一下 flag，前端没有任何提示。如果家属和患者真的同时在两台设备上编辑同一条 saved phrase，新数据会覆盖旧数据，旧数据无声丢失。
+
+**建议（按优先级）**：
+1. **短期**：当 `conflicted=true` 时，在前端给一个非阻塞的 toast / 通知中心入口，让家属能"知道发生过冲突"。
+2. **中期**：对 `pictograms` 的用户编辑（如果将来开放）改用 CRDT 风格，因为多人协作维护图库是真实场景。
+3. **长期**：评估 [Automerge](https://automerge.org/) 或 [Yjs](https://yjs.dev/)。但**只在用户量级 + 协作需求实际出现后**再做。
+
+---
+
+## 7. 状态管理：Zustand 5
+
+### 现状
+
+- 4 个 store：`app-store`、`auth-store`、`conversation-store`、`settings-store`。
+- 每个 store 用一个 `create()` 调用，约 100-150 行。
+- selectors 直接用 `useAppStore((s) => s.xxx)`。
+
+### 意图
+
+- 比 Redux 轻得多，又比纯 Context 性能更稳定（Context 全树重渲染问题）。
+
+### 证据
+
+> "Zustand ~3KB，1000 组件单次更新 12ms；Redux Toolkit 18ms；Jotai 14ms。"
+> "30 屏以下的应用想要简洁就选 Zustand。"
+> ([State Management in 2026](https://dev.to/jsgurujobs/state-management-in-2026-zustand-vs-jotai-vs-redux-toolkit-vs-signals-2gge))
+
+图语家目前界面在 30 屏以内（主沟通界面 + 抽屉若干 + 调试页），**完美命中 Zustand 的最佳应用场景**。
+
+### 评价
+
+✅ **零异议**。
+
+🤔 **小提醒**：如果将来引入大量"派生状态 + 自动同步"（如根据 selectedPictograms 实时算 candidatesPreview），可以考虑给 hot path 单独用 Jotai 的 atom，避免 Zustand 中间层重计算。但目前完全没必要。
+
+---
+
+## 8. AI 集成：服务端代理 OpenAI 兼容 endpoint
+
+### 现状
+
+- 客户端只调本地 `/api/ai/sentences`、`/api/ai/resegment`、`/api/ai/health`。
+- 服务端读环境变量 `AI_API_KEY` / `AI_BASE_URL` / `AI_MODEL`，再 forward 到上游 LLM。
+- AI Key **从不进客户端 bundle**（README 明确强调）。
+
+### 意图
+
+- 防止 API Key 泄露。
+- 屏蔽上游 provider 切换，前端无感知。
+- 服务端可以加 rate limit、审计、内容过滤（虽然目前还没加）。
+
+### 证据
+
+> "2026 年共识：服务端代理是生产应用的首选。直连客户端会暴露 key、无审计、无 rate limit。" ([How API Gateways Proxy LLM Requests](https://api7.ai/learning-center/api-gateway-guide/api-gateway-proxy-llm-requests))
+
+> "LLM 安全网关坐在应用和 LLM API 之间，镜像 OpenAI /v1/chat/completions endpoint，让应用无需修改。" ([Top 5 LLM Gateways in 2026](https://www.getmaxim.ai/articles/top-5-llm-gateways-in-2026-for-enterprise-grade-reliability-and-scale/))
+
+Cboard 也是同样思路——`cboard-ai-engine` 在服务端使用 OpenAI Node SDK ([cboard-ai-engine GitHub](https://github.com/cboard-org/cboard-ai-engine))。
+
+### 评价
+
+✅ **完全正确**。早期版本（`tuyujia` 仓库）把 key 放在前端，新版（`picinterpreter`）改成后端代理，这个迁移做得很对。
+
+⚠️ **目前还缺三件事**：
+1. **rate limit**：恶意用户或代码 bug 可以瞬间消耗 token 配额。建议给 deviceId 加每分钟 N 次的滑动窗口限制。
+2. **结构化日志**：记录每次调用的耗时、token 消耗、模型名，便于成本归因。
+3. **降级策略**：当上游 LLM 故障时，回退到 `template-nlg`（项目里已经有这个文件了，但需要在 `server-nlg` 失败时自动 fallback）。
+
+🤔 **更进一步**：如果未来对 AI 质量要求变高，可以考虑 [LiteLLM](https://docs.litellm.ai/docs/) 或 [Bifrost](https://wso2.com/library/blogs/litellm-alternatives/) 做多厂商路由 + 故障转移。但目前一个上游就够用。
+
+---
+
+## 9. 语音：Web Speech API（原生 ASR + TTS）
+
+### 现状
+
+- ASR：`useWebSpeech` hook 用 `window.SpeechRecognition` / `webkitSpeechRecognition`。
+- TTS：`web-speech-tts` provider 用 `speechSynthesis`。
+- 不支持的浏览器（Firefox 桌面、Safari iOS 旧版本）会隐藏按钮。
+
+### 意图
+
+- 0 成本、0 隐私顾虑——所有语音数据都在设备本地处理。
+- 不需要后端音频流量。
+
+### 证据
+
+> "Chrome/Edge 桌面、Android Chrome、Safari macOS 14+ 都支持 Web Speech API。" （来自 `use-web-speech.ts` 文件头注释）
+
+iOS Safari 的 SpeechRecognition 实际上**走 Apple 设备本地引擎**，不需要互联网（这是上一轮对话里用户给我纠正的细节）。
+
+### 评价
+
+✅ **AAC 项目最合理的选型**。理由：
+1. 失语症患者的语音可能不清晰，发回云端会触发隐私顾虑（医疗 / 患者数据）。
+2. 离线可用是硬约束。
+3. Web Speech API 的识别准确度对照护者输入（清晰中文 / 英文）够用。
+
+⚠️ **不支持的浏览器没有降级方案**。Firefox 桌面用户会完全失去语音输入。如果后续想覆盖更广，可以选择性接 [WhisperX](https://github.com/m-bain/whisperX) 或 [whisper-web](https://github.com/xenova/whisper-web)（基于 transformers.js + WebGPU），离线运行。**但优先级低**——iOS / Android / Chrome 已经覆盖 90%+ 的目标用户。
+
+---
+
+## 10. 拖拽：dnd-kit
+
+### 现状
+
+- `SelectionTray` 里用 `@dnd-kit/core` + `@dnd-kit/sortable` 做图片序列重排。
+- PointerSensor + TouchSensor 双套，移动端有 200ms 长按延迟。
+
+### 意图
+
+- 让患者把已选图片"拖来拖去"调整顺序——这是 AAC 应用的标准交互。
+- dnd-kit 比 react-dnd / react-beautiful-dnd 现代很多（无 HTML5 DnD API 依赖、原生触屏支持、accessible）。
+
+### 证据
+
+dnd-kit 是 2024-2026 年 React 拖拽场景的事实标准（react-beautiful-dnd 已停止维护）。
+
+### 评价
+
+✅ **没问题**。
+
+⚠️ **触屏长按 200ms 对失语症 / 老年用户可能略长**。建议做一组用户实测，必要时降到 100ms 或加上"长按反馈视觉提示"。
+
+---
+
+## 11. PWA / Service Worker
+
+### 现状
+
+- `public/sw.js` 存在但 `NEXT_PUBLIC_ENABLE_SERVICE_WORKER` **默认关闭**。
+- 部署后会主动清理旧 cache 和注册的 SW（来自 README）。
+
+### 意图
+
+- 避免在还没稳定时就让用户被旧静态资源卡住——典型的 SW 反模式（"无法刷新到最新版"）。
+- 等核心功能稳定后再开。
+
+### 证据
+
+> "Next.js 没有官方内置的 Service Worker 配置，需要手动整合或用 next-pwa（正在做 App Router 支持）。" ([Building Native-Like Offline Experience in Next.js PWAs](https://www.getfishtank.com/insights/building-native-like-offline-experience-in-nextjs-pwas))
+
+> "Next.js App Router 生成 RSC payload 是动态的——这些路由用 NetworkFirst/NetworkOnly；静态 JS/CSS chunks 用 CacheFirst（content-hashed 永不变）。" ([Building Offline-First with Next.js](https://nextjs.org/docs/app/guides/progressive-web-apps))
+
+### 评价
+
+✅ **保守但正确的姿态**。AAC 项目一旦因为 SW 缓存导致老人 / 患者打不开应用，影响远比"少了 offline 能力"严重。
+
+⚠️ **路线图建议**：
+1. 先用 Cache API + 自定义 SW 缓存**图片资源**（`/api/pictograms/search` 返回的图片 URL），这部分不会因为应用更新而过期，风险最低。
+2. 待 4-8 周稳定后，再开静态资源的 CacheFirst。
+3. 始终保持 RSC 路由 NetworkFirst，避免老旧 UI。
+
+---
+
+## 12. 测试：Vitest + Testing Library + jsdom
+
+### 现状
+
+- 11 个测试文件，148 个用例。
+- utils 走纯函数单测，components 走 RTL（刚加完，1 个文件）。
+- 覆盖率门槛：`lines/functions ≥ 70%`（仅 utils）。
+
+### 意图
+
+- 比 Jest 更快的 vitest，与 Vite 生态对齐。
+- 组件测试基础设施刚刚补齐。
+
+### 评价
+
+✅ **utils 单测扎实**。`ai-resegment.test.ts` 覆盖了 17 个边界情况，质量很高。
+
+⚠️ **e2e 完全缺失**。AAC 这种"多步交互流程"特别需要 e2e——例如"选 3 张图 → 生成候选句 → 点击播报 → 验证 TTS 调用"。建议引入 [Playwright](https://playwright.dev/) 做关键路径回归（5-10 条最多），重点保护：
+1. 患者主流程：表达模式选图 → 生成 → 播报。
+2. 接收模式：输入文字 → 匹配图片 → 全屏展示。
+3. 紧急求助：一键播报。
+
+---
+
+## 13. 部署：Next.js standalone + 阿里云 + GitHub Actions + systemd
+
+### 现状
+
+- `next build` 输出 `standalone`。
+- GitHub Actions 通过 SSH 上传到阿里云 + 远程重启。
+- 推荐 systemd / pm2 管理进程。
+
+### 评价
+
+✅ **务实**。对一个个人 / 小团队项目而言，自托管阿里云比 Vercel 便宜很多（特别是国内访问速度），把 GitHub Actions 当 CI 用是合理的。
+
+⚠️ **回滚机制**？目前看不到"上一版构建保留 N 份 + 一键回滚"的脚本。建议：
+1. 把每次部署的 `standalone/` 目录命名为 `releases/<git-sha>/`，用 symlink `current` 指过去。
+2. 回滚就是切换 symlink。
+3. 这是 [Capistrano-style](https://capistranorb.com/) 的标准做法。
+
+---
+
+## 综合判断
+
+### 整体评分：**B+ → A-**
+
+这是一份**远超个人项目平均水平**的架构。亮点：
+
+1. ⭐ **AGENTS.md 是稀缺资产**：明文 AAC UX 章程，对失语症患者人群的尊重写在了规则里。
+2. ⭐ **同步架构有教科书级别的严谨**：anonymous device → user 升级、changeId 单调游标、syncOutbox 幂等批量。
+3. ⭐ **AI 走后端代理这一步迁移做得对**：原版 `tuyujia` 把 key 放前端，新版及时改正了。
+4. ⭐ **schema 设计有规范感**：版本管理、optimistic locking、token 哈希全都到位。
+
+### 需要改进的优先级（高 → 低）
+
+| 优先级 | 项目 | 工作量 | 风险等级 |
+|--------|------|--------|---------|
+| **P0** | LLM 服务端加 rate limit | 0.5 天 | 🔴 token 烧钱风险 |
+| **P0** | 图片二进制离线缓存（Cache API） | 1-2 天 | 🟠 离线时图片显示不出来 |
+| **P0** | E2E 关键路径（Playwright，5-10 用例） | 2-3 天 | 🟠 主流程回归风险 |
+| **P1** | `pictograms` / `categories` 纳入同步 | 2 天 | 🟡 跨设备体验不一致 |
+| **P1** | `conflicted=true` 给前端可见提示 | 0.5 天 | 🟡 数据静默丢失 |
+| **P1** | 部署回滚 symlink 机制 | 0.5 天 | 🟡 故障恢复慢 |
+| **P2** | AGENTS.md ↔ WCAG 2.2 对照清单 | 0.5 天 | 🟢 合规审计需要 |
+| **P2** | AI 失败时 server-nlg → template-nlg 自动回退 | 0.5 天 | 🟢 体验韧性 |
+| **P2** | AI 调用结构化日志 | 1 天 | 🟢 成本归因 |
+
+### 长期方向
+
+- **不必折腾的事**：Next.js → Vite 拆分、MySQL → Postgres、Zustand → Jotai、CRDT 化同步——这些都是"在没撞墙之前不要预先优化"的典型案例。
+- **值得保持关注的事**：WebGPU 上的本地 LLM（让 NLG 也能离线）、Whisper-web 替代 Web Speech API、SQLite WASM (OPFS) 替代 IndexedDB——任意一项成熟到生产级时再认真考虑。
+
+---
+
+## 参考来源
+
+### AAC 领域开源参考方案
+- [AsTeRICS Grid GitHub](https://github.com/asterics/AsTeRICS-Grid) — 同领域最完整的开源实现
+- [AsTeRICS Grid 学术论文（Springer Nature, 2024）](https://link.springer.com/chapter/10.1007/978-3-031-62849-8_16) — 架构论证
+- [Cboard GitHub](https://github.com/cboard-org/cboard) — 浏览器端 React AAC
+- [cboard-ai-engine](https://github.com/cboard-org/cboard-ai-engine) — Cboard 的 AI 模块
+- [Open Assistive: AsTeRICS Grid 介绍](https://openassistive.org/item/asterics-grid-5tw/)
+- [augmentative-and-alternative-communication GitHub Topic](https://github.com/topics/augmentative-and-alternative-communication)
+
+### 状态管理与本地优先
+- [State Management in 2026: Zustand vs Jotai vs Redux Toolkit vs Signals](https://dev.to/jsgurujobs/state-management-in-2026-zustand-vs-jotai-vs-redux-toolkit-vs-signals-2gge)
+- [Local-First Software Development Patterns for 2026](https://tech-champion.com/software-engineering/the-local-first-manifesto-why-the-cloud-is-losing-its-luster-in-2026/)
+- [Awesome Local-First List](https://github.com/alexanderop/awesome-local-first)
+- [Why Local-First Software Is the Future and its Limitations (RxDB)](https://rxdb.info/articles/local-first-future.html)
+
+### 同步与冲突解决
+- [CRDTs Explained: Conflict-Free Replicated Data Types](https://www.designgurus.io/blog/crdts-for-eventual-consistency)
+- [The Cascading Complexity of Offline-First Sync: Why CRDTs Alone Aren't Enough](https://dev.to/biozal/the-cascading-complexity-of-offline-first-sync-why-crdts-alone-arent-enough-2gf)
+- [Offline sync & conflict resolution patterns (Sachith Dassanayake, 2026)](https://www.sachith.co.uk/offline-sync-conflict-resolution-patterns-architecture-trade%E2%80%91offs-practical-guide-feb-19-2026/)
+- [IDBSideSync: IndexedDB + CRDT](https://github.com/clintharris/IDBSideSync)
+
+### LLM 网关与安全
+- [How API Gateways Proxy LLM Requests](https://api7.ai/learning-center/api-gateway-guide/api-gateway-proxy-llm-requests)
+- [Top 5 LLM Gateways in 2026](https://www.getmaxim.ai/articles/top-5-llm-gateways-in-2026-for-enterprise-grade-reliability-and-scale/)
+- [Best LiteLLM Alternatives in 2026](https://wso2.com/library/blogs/litellm-alternatives/)
+
+### Next.js + PWA + Dexie
+- [Next.js 15 发布说明](https://nextjs.org/blog/next-15)
+- [Building Native-Like Offline Experience in Next.js PWAs](https://www.getfishtank.com/insights/building-native-like-offline-experience-in-nextjs-pwas)
+- [Build Offline-First PWA with React, Dexie.js & Workbox](https://www.wellally.tech/blog/build-offline-pwa-react-dexie-workbox)
+- [PWA + Next.js 15: React Server Components & Offline-First (Medium)](https://medium.com/@mernstackdevbykevin/progressive-web-app-next-js-15-16-react-server-components-is-it-still-relevant-in-2025-4dff01d32a5d)
+
+### 无障碍标准
+- [WCAG 2.2 Checklist: Complete 2026 Compliance Guide](https://www.levelaccess.com/blog/wcag-2-2-aa-summary-and-checklist-for-website-owners/)
+- [W3C WCAG 2.2 Recommendation](https://www.w3.org/TR/WCAG22/)
+- [WCAG 3.0 Status 2026](https://web-accessibility-checker.com/en/blog/wcag-3-0-guide-2026-changes-prepare)
+
+---
+
+*本评审基于 2026-04-28 commit `c138c4c` 的代码状态。架构是活的——优先级会随着用户量、团队规模、合规要求变化。建议每 6 个月做一次复审。*

--- a/docs/ASR_PIPELINE_RESEARCH.md
+++ b/docs/ASR_PIPELINE_RESEARCH.md
@@ -1,0 +1,521 @@
+# ASR → 分词 → 语义分词 → 图片匹配：最佳实践研究报告
+
+> 研究日期：2026-04-29  
+> 作者：架构研究（基于本地克隆代码的第一手分析）  
+> 研究目的：为图语家 Receiver 模式管线寻找升级路径
+
+---
+
+## 一、研究范围与项目清单
+
+| 项目 | 语言 | 本地路径 | 核心价值 |
+|------|------|----------|----------|
+| cboard-ai-engine | TypeScript | `D:\used-by-Claude\aac-research\cboard-ai-engine` | 生产级 LLM + ARASAAC API 集成参考 |
+| pictoBERT | Python (Jupyter) | `D:\used-by-Claude\aac-research\pictoBERT` | 唯一以 ARASAAC 词汇表为词表训练的 BERT 模型 |
+| OpenAAC (RonanOD) | Dart + Deno TS | `D:\used-by-Claude\aac-research\OpenAAC` | 向量嵌入 + pgvector 语义搜索参考实现 |
+| text2vec | Python | `D:\used-by-Claude\aac-research\text2vec` | 最优中文语义嵌入库，含 jieba + CoSENT |
+
+---
+
+## 二、现有图语家管线分析
+
+### 2.1 当前架构（Receiver 模式）
+
+```
+照护者语音
+    ↓
+useWebSpeech → Web Speech API（浏览器原生，zh-CN）
+    ↓
+segmentText()
+  ├─ Intl.Segmenter(zh-CN, {granularity:'word'})  [Chrome 87+]
+  ├─ 手工规则：SPLIT_COMPOUNDS（17个复合词拆分）
+  ├─ MERGE_PAIRS（11个词语合并规则）
+  └─ STOP_CHARS 过滤标点停用词
+    ↓
+matchTextToImages()  [text-to-image-matcher.ts]
+  ├─ Strategy 1: 精确匹配 labels.zh
+  ├─ Strategy 2: 匹配 synonyms 字段
+  ├─ Strategy 3: 通过 lexicon.ts 查找同义词主词
+  └─ Strategy 4: 包含匹配（token 含有某个 label，取最长）
+    ↓
+若 matchRate < 0.6 或存在 unmatchedTokens
+    ↓ (aiResegment.ts)
+LLM 重分词（/api/ai/resegment）
+  └─ 将原文映射到图库词汇列表（附图库词汇 hint）
+    ↓
+preSegmented 词序列 → 再次 matchTextToImages()
+    ↓
+若仍有未匹配 → runtime-pictogram-search.ts → ARASAAC 在线 API
+```
+
+### 2.2 当前设计的优点
+
+- **零依赖**：`Intl.Segmenter` 是浏览器原生 API，完全离线，无 Python runtime
+- **渐进增强**：`char-split` 降级路径覆盖不支持 `Intl.Segmenter` 的旧浏览器
+- **LLM 降级链**：规则 → AI 重分词 → 在线搜索，三层冗余
+- **LLM API Key 不暴露客户端**：通过 Next.js API route 代理（`/api/ai/resegment`）
+
+### 2.3 当前设计的局限
+
+| 问题 | 根因 | 影响 |
+|------|------|------|
+| `Intl.Segmenter` 对 AAC 领域词汇召回率不高 | 通用分词引擎不懂照护场景语境 | "肚子疼" 不能正确分词为["肚子","疼"] |
+| 图库词汇覆盖依赖手工 `lexicon.ts` | 1000+ 图片，只维护了部分同义词 | 图库里有"疼痛"，但匹配不到口语"疼" |
+| 匹配层无语义相似度 | 4 种策略全部是字符串比较 | 近义词（"开心"≈"高兴"）无法匹配 |
+| LLM 重分词只有 JSON 数组输出 | 依赖 LLM 正确格式化 | 偶发格式错误导致降级失败 |
+| ARASAAC 在线搜索作为最终兜底 | 无本地语义向量索引 | 需要网络，延迟 200ms+ |
+
+---
+
+## 三、项目深度研究
+
+### 3.1 cboard-ai-engine（TypeScript，v1.9.0）
+
+**GitHub:** https://github.com/cboard-org/cboard-ai-engine
+
+#### 架构图
+
+```
+prompt（自然语言话题）
+    ↓
+getWordSuggestions() → GPT-4o-mini
+  └─ System prompt: "act as a speech pathologist, return exactly N words in {w1, w2, w3} format"
+    ↓
+[word1, word2, ..., wordN]  （每个词是可以搜索的关键词）
+    ↓
+fetchPictogramsURLs()
+  ├─ ARASAAC: GET /{lang}/bestsearch/{word}  → 返回图片 ID 列表，取第一个
+  └─ GlobalSymbols: GET /api/v1/labels?query={word}&language={lang} → 聚合 60k+ 图库
+```
+
+#### 关键代码模式（symbolSets.ts）
+
+```typescript
+// ARASAAC 搜索策略：先 bestsearch，降级到普通 search
+async function fetchArasaacData(URL, word, language) {
+  const bestSearchUrl = `${URL}/${language}/bestsearch/${encodeURIComponent(word)}`
+  try {
+    const { data } = await axios.get(bestSearchUrl)
+    return data  // 返回按相关性排序的图片数组
+  } catch {
+    // 降级到普通搜索
+    let { data } = await axios.get(searchUrl)
+    if (data.length > 5) data = data.slice(0, 5)
+    return data
+  }
+}
+```
+
+#### 架构洞察
+
+1. **ARASAAC `/bestsearch/` API** 是语义感知搜索，比 `/search/` 返回结果更精准
+2. 完全依赖 **LLM 做词汇规范化**：把任意口语词汇转为标准化的可搜索关键词
+3. `removeDiacritics()` 去除变音符号再搜索 — 对西班牙语 ARASAAC 符合标签格式有效
+4. **无本地图库**：每次匹配都需要网络请求，不适合离线场景
+
+#### 对图语家的参考价值
+
+- **直接可用**：将现有 `runtime-pictogram-search.ts` 升级为 cboard 的 `bestsearch` 策略（当前用的是 `/search/`）
+- **GlobalSymbols 支持**：可作为 ARASAAC 搜索失败时的第二在线后备（覆盖 60k+ 图片，包含 Mulberry、Sclera 等）
+- **LLM prompt 模板**：语病理学家角色定义 + 动词用原形 + 精确 N 词格式，可改进现有 resegment 的 system prompt
+
+---
+
+### 3.2 pictoBERT（Python，ICASSP 2022 论文）
+
+**GitHub:** https://github.com/jayralencar/pictoBERT  
+**论文:** Expert Systems with Applications, Vol. 202, 2022
+
+#### 核心架构
+
+```
+CHILDES 儿语语料库
+    ↓
+supWSD（词义消歧）→ SemCHILDES（每个词标注 WordNet 义项）
+    ↓
+BERT-Large 词表替换：subword token → word-sense token
+（词汇表 ≈ WordNet 义项集 ≈ ARASAAC 图片集）
+    ↓
+预训练 MLM（Masked Language Model）
+    ↓
+PictoBERT（上下文感知的图片 ID 预测器）
+
+推理时：
+  context + [MASK] → PictoBERT → 下一个图片的 WordNet 义项（= 图片 ID）
+```
+
+#### 两种变体
+
+| 变体 | 词义表示 | 特点 |
+|------|----------|------|
+| PictoBERT-contextual | 所在句子的上下文嵌入 | 随语境消歧 |
+| PictoBERT-gloss | WordNet 义项定义文本嵌入 | 与具体句子无关，更泛化 |
+
+#### ARASAAC 微调版（最关键）
+
+`ARASAAC_fine_tuned_PictoBERT.ipynb` 实现了：
+1. ARASAAC 图片 → WordNet 义项映射（`arasaac_mapping.csv`，可下载）
+2. 将 SemCHILDES 过滤为只保留 ARASAAC 词汇集内的句子
+3. 在此子集上微调 PictoBERT
+
+输出：给定前 K 个图片（词义序列）→ 预测最可能的下一个图片
+
+#### 架构洞察
+
+1. **词义（Word Sense）是图片的最佳代理**：ARASAAC 中每个图片对应一个精确义项，而 WordNet 正好提供精确义项的唯一 ID
+2. **PictoBERT 解决的是"下一个图片预测"而非"文本→图片映射"**：两者根本上不同
+3. 论文中 N-gram 基线胜过某些 PictoBERT 变体（较小上下文窗口时），说明图片序列有强 Markov 特性
+4. 中文化路径：需要中文儿语/照护语料库 + 中文 WordNet → 工程量极大，近期不可行
+
+#### 对图语家的参考价值
+
+**近期不适用**（中文化难度高），但：
+- `arasaac_mapping.csv`（图片 ID → WordNet 义项）可下载作为语义知识库
+- **架构启示**：当用户连续输入时（Receiver 模式），可用前几个已匹配图片的序列预测下一个图片候选，减少重分词需求
+- 中期可探索用中文 BERT（如 MacBERT）做类似预训练，语料用现有 CHILDES 的中文部分
+
+---
+
+### 3.3 OpenAAC（Dart/Flutter + Supabase Edge Functions）
+
+**GitHub:** https://github.com/RonanOD/OpenAAC
+
+#### 架构图
+
+```
+用户输入词语
+    ↓
+Supabase Edge Function: getImages
+    ↓
+OpenAI text-embedding-3-small → 1536-dim 向量
+    ↓
+supabaseClient.rpc('match_images', {
+  query_embedding: [...],
+  match_threshold: 0.78,
+  match_count: 1
+})
+    ↓ (pgvector 余弦距离搜索)
+最近邻图片（余弦相似度 > 0.78 才返回）
+    ↓
+若无匹配 → generateImage → DALL-E 3 生成新图片
+```
+
+#### 关键阈值
+
+- `vectorMatchThreshold = 0.78`：低于此相似度则不返回现有图片，而是生成新图片
+- 使用 `text-embedding-3-small`（1536维，比 ada-002 更小更快）
+
+#### 核心 SQL（pgvector）
+
+```sql
+-- 预建 IVFFlat 索引
+CREATE INDEX ON images USING ivfflat (embedding vector_cosine_ops);
+
+-- 运行时搜索
+CREATE FUNCTION match_images(query_embedding vector(1536), match_threshold float, match_count int)
+RETURNS TABLE(id bigint, word text, path text, similarity float)
+AS $$
+  SELECT id, word, path, 1 - (embedding <=> query_embedding) AS similarity
+  FROM images
+  WHERE 1 - (embedding <=> query_embedding) > match_threshold
+  ORDER BY embedding <=> query_embedding
+  LIMIT match_count;
+$$ LANGUAGE sql STABLE;
+```
+
+#### 架构洞察
+
+1. **向量阈值比排名更安全**：`match_threshold=0.78` 意味着拒绝返回相似度不足的结果，而不是强制返回最近邻（可能语义无关）
+2. **完全依赖云端**：OpenAI Embedding API + Supabase — 每次匹配都需要网络，延迟约 300-600ms
+3. **生成式兜底**：DALL-E 3 为没有现有图片的词创建新图片，这是 TuYuJia 无法使用的路径（照护 app 需要固定且经过审核的图片集）
+4. **Upstash Redis 限流**：Edge Function 里集成了 Ratelimit，防止滥用
+
+#### 对图语家的参考价值
+
+**离线化改造路径**（核心价值）：
+- 将 OpenAI Embedding 替换为本地 `BAAI/bge-m3` 或 `shibing624/text2vec-base-chinese`
+- 将 pgvector 替换为本地 SQLite + `better-sqlite3` + 预计算嵌入向量（JSON 格式存储于 IndexedDB）
+- 将余弦距离计算移到 Web Worker 中执行
+
+---
+
+### 3.4 text2vec（Python，shibing624）
+
+**GitHub:** https://github.com/shibing624/text2vec  
+**Stars:** 5,000+
+
+#### 架构图
+
+```python
+# 核心接口：Similarity
+sim = Similarity("shibing624/text2vec-base-chinese")
+
+# 批量语义搜索
+query_embedding = sim.model.encode(["疼"])           # 1 × 768
+corpus_embeddings = sim.model.encode(all_labels)    # N × 768
+scores = semantic_search(query_embedding, corpus_embeddings, top_k=5)
+# → [{'corpus_id': 42, 'score': 0.91}, ...]
+```
+
+#### 底层实现
+
+- 基础模型：`hfl/chinese-macbert-base`（MacBERT，专为中文语义任务优化）
+- 训练方法：CoSENT（Cosine Sentence）— 基于余弦相似度的对比学习
+- 编码策略：`MEAN`（最后一层 hidden state 的均值池化）
+- 向量维度：768（MacBERT-base）
+- `semantic_search()` 支持**分块矩阵乘法**，可在 CPU 上高效处理 100k 条目的语料库
+
+#### 关键类
+
+| 类/函数 | 用途 |
+|---------|------|
+| `SentenceModel` | 文本 → 向量编码（支持 BERT / MacBERT / bge） |
+| `Similarity` | 两文本相似度（COSINE / WMD） |
+| `semantic_search()` | 向量 → top-k 最近邻检索 |
+| `JiebaTokenizer` | WMD 场景下的中文 jieba 分词 |
+
+#### 架构洞察
+
+1. **MacBERT + CoSENT 是目前中文语义相似度的最佳开源组合**（优于 BERT-Chinese + NSP）
+2. `semantic_search()` 的核心是矩阵乘法（`torch.mm(a_norm, b_norm.T)`），可直接在浏览器的 WASM/WebGL 中实现
+3. WMD（Word Mover's Distance）需要 jieba 分词，召回率高但计算慢，不适合实时场景
+4. 支持 `BAAI/bge-m3` 等更大模型，一行参数切换
+
+---
+
+## 四、架构对比总结
+
+| 维度 | 图语家现状 | cboard-ai-engine | OpenAAC | text2vec + bge-m3 |
+|------|-----------|------------------|---------|-------------------|
+| 匹配方式 | 字符串精确/包含匹配 | LLM → 关键词 → API 搜索 | 向量余弦相似度 | 向量余弦相似度 |
+| 离线能力 | ✅ 完全离线 | ❌ 需要 OpenAI + ARASAAC | ❌ 需要 OpenAI + Supabase | ✅ 模型本地化后离线 |
+| 语义理解 | 无（字符串匹配） | 有（LLM 语义规范化） | 有（嵌入向量距离） | 有（嵌入向量距离） |
+| 近义词处理 | 手工 `lexicon.ts` | LLM 自动处理 | 向量自动处理 | 向量自动处理 |
+| 中文支持 | ✅ 专门设计 | ⚠️ 通过 i18n，质量一般 | ❌ 主要英语 | ✅ 专门优化 |
+| 延迟 | ~10ms（本地） | 500ms+（API） | 300-600ms（API） | ~50ms（CPU 本地） |
+| 置信度分数 | 无（只有 matchType） | 无（第一个结果） | 有（余弦相似度） | 有（余弦相似度） |
+| 兜底策略 | ARASAAC 在线 API | GlobalSymbols API | DALL-E 生成 | 可配置阈值拒绝 |
+
+---
+
+## 五、推荐的升级路径
+
+### 5.1 近期（P1）：改进 Strategy 3 — 引入轻量语义词典
+
+**问题：** 当前 `lexicon.ts` 只有约 200 个手工维护的同义词条目。  
+**方案：** 用 Python 脚本基于 `text2vec` 为所有图库 label 预计算余弦相似度，生成一个更大的同义词扩展文件。
+
+```python
+# 离线脚本：生成图库 → 口语词汇的相似度矩阵
+from text2vec import SentenceModel
+import json, numpy as np
+
+model = SentenceModel("shibing624/text2vec-base-chinese")
+# labels = 所有图库 zh labels（约 1000 个）
+# colloquial_variants = 常见口语变体词库（手工整理 + 网络爬取）
+label_embs = model.encode(labels)          # 1000 × 768
+variant_embs = model.encode(colloquial)   # M × 768
+# 计算余弦相似度，阈值 > 0.75 的对写入 lexicon_extended.json
+```
+
+**输出：** `lexicon_extended.ts` — 替换现有 `lexicon.ts`，覆盖率提升 3-5x
+
+---
+
+### 5.2 中期（P2）：服务端语义向量匹配 API
+
+**问题：** 浏览器端无法运行 768 维向量模型（~400MB），Web Worker 也无法加载。  
+**方案：** 新增 Next.js API route `/api/semantic-match`，服务端持久化加载 `bge-m3` 模型（用 Python subprocess 或独立 FastAPI 微服务）。
+
+```
+客户端：未匹配的 tokens
+    ↓ POST /api/semantic-match
+服务端：
+  1. tokens → text2vec 编码 → 查询向量
+  2. 与预计算图库向量索引做余弦搜索（FAISS）
+  3. 返回：[{token, pictogramId, score}]
+    ↓
+客户端：用 score > 0.75 的结果填充 'none' 槽位
+```
+
+**技术栈：** Python + FastAPI + `shibing624/text2vec-base-chinese` + `faiss-cpu`  
+**估计延迟：** 50-100ms（局域网服务端），语义匹配率提升 20-30%
+
+---
+
+### 5.3 中期（P2）：改进在线搜索 — 双 API 策略 + GlobalSymbols 后备
+
+**问题：** 实测（见第六节）发现：
+- `/search/` 覆盖率更高（"吃饭"、"开心"等有结果）
+- `/bestsearch/` 质量更高但覆盖率低（对"吃饭"返回 0 结果）
+- ARASAAC 中文数据库自身有缺口（"疼"、"痛"均无结果）
+
+**方案：** 参考 `cboard-ai-engine/src/lib/symbolSets.ts` 的**降级策略**：
+
+```typescript
+async function searchArasaac(keyword: string, language = 'zh') {
+  // 1. 先尝试 bestsearch（质量更高）
+  const bestUrl = `https://api.arasaac.org/api/pictograms/${language}/bestsearch/${encodeURIComponent(keyword)}`
+  const best = await fetch(bestUrl).then(r => r.json()).catch(() => [])
+  if (best.length > 0) return best.slice(0, 5)
+  
+  // 2. bestsearch 无结果则降级到 search
+  const searchUrl = `https://api.arasaac.org/api/pictograms/${language}/search/${encodeURIComponent(keyword)}`
+  const results = await fetch(searchUrl).then(r => r.json()).catch(() => [])
+  if (results.length > 0) return results.slice(0, 5)
+  
+  // 3. ARASAAC 中文无结果则尝试英文（如 "疼" → "pain"，需 lexicon 翻译）
+  // 4. 最终兜底：GlobalSymbols API（覆盖 60k+ 图片）
+  const globalUrl = `https://www.globalsymbols.com/api/v1/labels/?query=${encodeURIComponent(keyword)}&language=zh&language_iso_format=639-1`
+  return await fetch(globalUrl).then(r => r.json()).catch(() => [])
+}
+```
+
+**实现成本：** 低（修改 `runtime-pictogram-search.ts`，增加 4 层降级）  
+**预期效果：** 在线搜索覆盖率提升 20-30%（特别是 ARASAAC 中文缺口词语）
+
+---
+
+### 5.4 中期（P2）：改进 LLM resegment system prompt
+
+**问题：** 现有 resegment prompt 没有利用言语病理学领域框架。  
+**方案：** 参考 cboard-ai-engine 的 system prompt 设计：
+
+```typescript
+// 改进后的 resegment system prompt
+const systemPrompt = `你是一位语言康复治疗师（言语病理学家），正在帮助失语症患者将照护者的口语句子转换为图片沟通板上的词汇序列。
+
+任务：将输入句子分解为最适合在图片沟通板上显示的词语序列。
+
+规则：
+1. 优先使用以下图库词汇中已有的词语：${vocabularyHint}
+2. 动词使用原形（"走"而非"走了"，"吃"而非"吃了"）
+3. 保留核心语义词，过滤语气词（"啊"、"嗯"、"吧"）
+4. 返回 JSON 数组格式：["词1", "词2", "词3"]
+5. 数组长度 2-8 个词，不超过原句的词数`
+```
+
+---
+
+### 5.5 远期（P3）：WebAssembly 嵌入模型
+
+**目标：** 将轻量级嵌入模型运行在浏览器内，实现完全离线语义匹配。
+
+**可行路径：**
+- `@xenova/transformers`（Transformers.js）支持量化 ONNX 模型，在 WebWorker 中运行
+- `shibing624/text2vec-base-chinese` 的 ONNX 量化版（INT8）约 80MB，可通过 PWA 缓存
+- 初始化时异步加载（不阻塞 UI），热身后语义搜索延迟 < 100ms
+
+**当前成熟度：** Transformers.js 已在生产使用（HuggingFace Spaces、多个 PWA 项目）  
+**预计工期：** 2-3 周（含图库预计算嵌入向量的建设工作）
+
+---
+
+## 六、实测数据
+
+### 6.1 ARASAAC /search/ vs /bestsearch/ 中文对比（本机实测）
+
+| 词语 | `/search/` 结果 | `/bestsearch/` 结果 | 结论 |
+|------|----------------|---------------------|------|
+| 吃饭 | 3个, 首ID=36629 | **0个** | bestsearch 对"吃饭"无结果，search 更实用 |
+| 喝水 | 1个, ID=37207 | 1个, ID=37207 | 相同 |
+| 开心 | 7个, 首ID=3372 | **0个** | bestsearch 漏掉，search 更实用 |
+| 厕所 | 16个, 首ID=37331 | 7个, 首ID=37331 | bestsearch 过滤掉低相关结果，质量更高 |
+| 睡觉 | 4个, 首ID=6479 | 4个, 首ID=2369 | 两者首ID不同但标签均为"睡觉" |
+| 疼 | **0个** | **0个** | 两者均无 |
+| 帮助 | 8个 | 7个 | 接近 |
+| 妈妈/爸爸 | 1个 | 1个 | 完全一致 |
+
+**关键结论：** `/bestsearch/` 并非总是更优。对于中文，`/search/` 覆盖率反而更高。ARASAAC 的中文标签本身存在覆盖缺口（"疼"、"痛"在中文数据库中 0 结果，但"疼痛"有 1 个结果 ID=2367）。
+
+### 6.2 jieba 分词测试（本机实测）
+
+无自定义词典时的问题：
+- `今天不开心想睡觉` → `['今天', '不', '开', '心想', '睡觉']` — "不开心"被错误拆分
+- `帮我倒杯水喝` → `['帮', '我', '倒杯水', '喝']` — "倒杯水"被误合并
+- `我想看电视` → `['我', '想', '看电视']` — "看电视"未被拆分
+
+加入 AAC 词典后的改进（示例词典片段）：
+```
+肚子疼 5 v
+不开心 6 a
+上厕所 6 v
+```
+结果：`今天不开心想睡觉` 仍有问题（词典权重需要进一步调整），但 `我肚子疼想去厕所` → `['肚子疼', '厕所']` ✅
+
+**关键结论：** jieba 词典词频权重是关键——需要明确将 AAC 领域词汇（否定复合词等）标记为高频才能避免错误分割。
+
+### 6.3 架构差异总结
+
+```
+cboard-ai-engine 管线（实测）：
+  prompt → GPT-4o-mini（词汇规范化）→ ARASAAC /bestsearch/ → 第一个图片
+  优点：不依赖本地图库
+  缺点：每次完整 pipeline 都需要 OpenAI API + 网络，延迟 500ms+
+
+图语家当前管线（实测）：
+  speech → Intl.Segmenter → 4策略字符串匹配（<10ms）
+  → LLM 重分词（仅未命中词）→ ARASAAC /search/（仅最终兜底）
+  优点：离线优先，LLM 和在线仅作降级
+  缺点：字符串匹配层无语义理解
+
+OpenAAC 管线（代码分析）：
+  word → OpenAI embedding → pgvector cosine ≥0.78 → 图片
+  → 若无匹配 → DALL-E 3 生成
+  优点：语义匹配，无需字符串精确匹配
+  缺点：完全云端，DALL-E 生成不适合 AAC 固定图库场景
+```
+
+---
+
+## 八、参考资源
+
+### ARASAAC API 接口
+
+```
+# 关键词搜索（字符串匹配）
+GET https://api.arasaac.org/api/pictograms/{lang}/search/{keyword}
+
+# 最优搜索（语义排序，推荐）
+GET https://api.arasaac.org/api/pictograms/{lang}/bestsearch/{keyword}
+
+# 批量下载图片元数据
+GET https://api.arasaac.org/api/pictograms/all/{lang}
+
+# 图片静态资源
+https://static.arasaac.org/pictograms/{id}/{id}_500.png
+```
+
+### GlobalSymbols API
+
+```
+GET https://www.globalsymbols.com/api/v1/labels/?query={keyword}&language={lang}&language_iso_format=639-1
+# 覆盖 ARASAAC + Mulberry + Sclera + SymbolStix 等 60k+ 图片
+```
+
+### 推荐中文嵌入模型
+
+| 模型 | 大小 | 维度 | 适用场景 |
+|------|------|------|----------|
+| `shibing624/text2vec-base-chinese` | ~400MB | 768 | 服务端，中文专用 |
+| `BAAI/bge-m3` | ~2.3GB | 1024 | 服务端，中英跨语言 |
+| `Xenova/paraphrase-multilingual-MiniLM-L12-v2` | ~170MB | 384 | 浏览器 WASM，多语言 |
+
+### 关键论文
+
+1. **pictoBERT** (2022): Pereira et al., "PictoBERT: Transformers for Next Pictogram Prediction", Expert Systems with Applications, Vol. 202
+2. **LREC-COLING 2024**: "A Multimodal French Corpus for Speech-to-Pictogram Machine Translation" — 第一个语音→图片对齐数据集
+3. **Arasaac-WN** (LREC 2020): "Providing Semantic Knowledge for the AAC Domain" — ARASAAC 图片 ↔ WordNet 义项映射资源
+
+---
+
+## 七、执行优先级建议
+
+| 优先级 | 任务 | 预估工期 | 预期收益 |
+|--------|------|----------|----------|
+| **P0** | 改进在线搜索：bestsearch → search 双降级 + GlobalSymbols 后备 | 1天 | 覆盖率 +20%（ARASAAC 中文缺口词） |
+| **P0** | 改进 resegment system prompt（参考 cboard 的言语病理学角色定义） | 1天 | LLM 重分词质量 +20% |
+| **P1** | 用 text2vec 离线生成扩展词典替换 `lexicon.ts` | 3天 | 离线匹配率 +15% |
+| **P1** | 添加置信度分数到 `MatchedToken`（目前只有 matchType） | 2天 | UI 可展示不确定图片供用户确认 |
+| **P2** | 服务端 FastAPI 语义向量搜索微服务 | 1周 | 语义匹配率 +25% |
+| **P3** | Transformers.js + 量化 ONNX 模型运行在浏览器 Web Worker | 2-3周 | 完全离线语义匹配 |

--- a/docs/decision-index.md
+++ b/docs/decision-index.md
@@ -1,0 +1,49 @@
+# Decision Index
+
+Navigation map for current product and architecture decisions.
+**Issue bodies are the source of truth.** This file only links to them — do not copy decision content here.
+
+---
+
+## Confirmed Decisions
+
+| Area | One-line summary | Source | Status |
+|------|-----------------|--------|--------|
+| Receiver records | Two-phase write (draft → confirmed) + `ReceiverCorrection` table; `pictogramSequence` field on `Expression` | [#26](https://github.com/picinterpreter/picinterpreter/issues/26) | `status: decision-made` |
+| Text pipeline | 9-layer pipeline; layers 1–5 client/offline, layers 6–7 server/online; no jieba WASM in MVP | [#8](https://github.com/picinterpreter/picinterpreter/issues/8) | `status: decision-made` |
+| Account & sync semantics | `userId` / `patientId` / `workspaceId` as anonymous UUIDs (1:1:1 per device for MVP); sync fields: `baseVersion` / `serverVersion` / `conflicted`; per-entity conflict strategies, not pure LWW | [#27](https://github.com/picinterpreter/picinterpreter/issues/27) | `status: decision-made` |
+| Missing pictogram lifecycle | `MissingTokenRecord`: `new → suggested → resolved \| ignored`; tracks `occurrenceCount`, scenes, raw text samples, `suggestedPictogramId` / `resolvedPictogramId` | [#19](https://github.com/picinterpreter/picinterpreter/issues/19) | `status: decision-made` |
+| Patient-facing UI criteria | 44×44 px touch targets; ≤3 taps for core flow; icon-first; no technical errors exposed to patient | [#6](https://github.com/picinterpreter/picinterpreter/issues/6) | `status: decision-made` |
+| Pictogram license handling | Preserve per-pictogram `license` + `licenseUrl` fields; never assume a global license; ARASAAC is CC BY-NC-SA 4.0 (non-commercial) | [#10](https://github.com/picinterpreter/picinterpreter/issues/10), [#24](https://github.com/picinterpreter/picinterpreter/issues/24) | `status: decision-made` |
+| Pictogram privacy & sync scope | `scope: 'public' \| 'private' \| 'family'`; user-uploaded defaults to `private`; `private` never enters sync outbox | [#10](https://github.com/picinterpreter/picinterpreter/issues/10), [#24](https://github.com/picinterpreter/picinterpreter/issues/24) | `status: decision-made` |
+| Core library scope | *Approach* confirmed: scenario-based first (14 scenarios), ~300–500 range, pre-downloaded to IndexedDB. Specific vocabulary list is open — see below. | [#32](https://github.com/picinterpreter/picinterpreter/issues/32), [#11](https://github.com/picinterpreter/picinterpreter/issues/11) | `status: decision-made` |
+| Session boundary | Session = continuous scenario; new session on user action or 30-min idle suggestion; shared across express + receive flows | [#31](https://github.com/picinterpreter/picinterpreter/issues/31) | `status: decision-made` |
+
+---
+
+## Ready to Implement (decision made, not yet coded)
+
+| Area | Blocked by | Source |
+|------|-----------|--------|
+| Dexie v5 migration | — (this is the gate) | [#35](https://github.com/picinterpreter/picinterpreter/issues/35) |
+| Receiver data persistence | #35 Dexie v5 | [#26](https://github.com/picinterpreter/picinterpreter/issues/26) |
+| Missing token Dexie table | #35 Dexie v5 | [#19](https://github.com/picinterpreter/picinterpreter/issues/19) |
+| Fixture set (receiver test samples) | — | [#38](https://github.com/picinterpreter/picinterpreter/issues/38) |
+
+---
+
+## Open / Needs Design
+
+| Area | Open question | Source |
+|------|--------------|--------|
+| Core vocabulary content | Which exact ~300–500 pictograms cover the 14 scenarios? Needs review of existing seed + `/import` tool run | [#32](https://github.com/picinterpreter/picinterpreter/issues/32), [#11](https://github.com/picinterpreter/picinterpreter/issues/11) |
+| Board / PictureSet schema | Internal data model for OBF-compatible import; migration path from current flat Category model | [#11](https://github.com/picinterpreter/picinterpreter/issues/11), [#30](https://github.com/picinterpreter/picinterpreter/issues/30) |
+| Text pipeline sufficiency threshold | How much local matching (layers 1–5) is acceptable before requiring online fallback? Needs 50–100 fixture samples | [#8](https://github.com/picinterpreter/picinterpreter/issues/8), [#38](https://github.com/picinterpreter/picinterpreter/issues/38) |
+
+---
+
+## How to use this file
+
+- **Found a decision?** Open the linked issue. The `## Status` block at the top has the current conclusion and links to the definitive comment.
+- **Changing a decision?** Update the issue body. Update the row in this table only if the one-line summary changes.
+- **New decision landed?** Add a row here and update the issue label to `status: decision-made`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tuyujia",
       "version": "0.0.0",
       "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -29,6 +30,9 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@tailwindcss/postcss": "^4.2.3",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -38,11 +42,19 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^26.1.0",
         "tailwindcss": "^4.2.2",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmmirror.com/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -56,6 +68,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -88,7 +121,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -250,6 +282,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmmirror.com/@babel/template/-/template-7.28.6.tgz",
@@ -308,6 +350,121 @@
         "node": ">=18"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -325,7 +482,6 @@
       "resolved": "https://registry.npmmirror.com/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -360,6 +516,28 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmmirror.com/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2578,6 +2756,96 @@
         "tailwindcss": "4.2.3"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmmirror.com/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmmirror.com/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmmirror.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmmirror.com/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmmirror.com/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmmirror.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2588,6 +2856,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2626,7 +2902,6 @@
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2637,7 +2912,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2648,7 +2922,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2698,7 +2971,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -2981,7 +3253,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -3126,7 +3397,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3144,6 +3414,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.14.0.tgz",
@@ -3159,6 +3439,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -3194,6 +3485,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmmirror.com/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/assertion-error": {
@@ -3285,7 +3586,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3451,12 +3751,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmmirror.com/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmmirror.com/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3475,6 +3810,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmmirror.com/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3507,6 +3849,16 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -3533,8 +3885,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmmirror.com/dexie/-/dexie-4.4.2.tgz",
       "integrity": "sha512-zMtV8q79EFE5U8FKZvt0Y/77PCU/Hr/RDxv1EDeo228L+m/HTbeN2AjoQm674rhQCX8n3ljK87lajt7UQuZfvw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/dexie-react-hooks": {
       "version": "4.4.0",
@@ -3545,6 +3896,14 @@
         "dexie": ">=4.2.0-alpha.1 <5.0.0",
         "react": ">=16"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmmirror.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -3598,6 +3957,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
@@ -3634,7 +4006,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4071,12 +4442,53 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmmirror.com/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -4131,6 +4543,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4153,6 +4575,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-property": {
       "version": "1.0.2",
@@ -4233,6 +4662,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmmirror.com/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4621,6 +5090,17 @@
         "url": "https://github.com/sponsors/wellwelwel"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmmirror.com/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz",
@@ -4670,6 +5150,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4844,6 +5334,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmmirror.com/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nypm": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
@@ -4947,6 +5444,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
@@ -4991,7 +5501,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5049,13 +5558,42 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmmirror.com/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prisma": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
       "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -5116,7 +5654,6 @@
       "resolved": "https://registry.npmmirror.com/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5126,13 +5663,20 @@
       "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.5"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmmirror.com/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -5216,6 +5760,20 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5267,11 +5825,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmmirror.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -5415,6 +5993,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5463,6 +6054,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.3",
@@ -5528,6 +6126,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmmirror.com/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmmirror.com/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmmirror.com/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmmirror.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5566,7 +6210,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5695,7 +6338,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5774,7 +6416,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -5859,6 +6500,80 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmmirror.com/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmmirror.com/which/-/which-2.0.2.tgz",
@@ -5902,6 +6617,45 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/yallist/-/yallist-3.1.1.tgz",
@@ -5928,7 +6682,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/postcss": "^4.2.3",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -49,6 +52,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",

--- a/src/components/SelectionTray/__tests__/SelectionTray.test.tsx
+++ b/src/components/SelectionTray/__tests__/SelectionTray.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * SelectionTray 组件测试
+ *
+ * 覆盖：空状态提示、图片标签渲染、清空操作、单项移除、"说"按钮禁用态。
+ * dnd-kit 的拖拽能力在 jsdom 中无法完整模拟，故将其存根，
+ * 保证测试专注于业务逻辑而非拖拽底层实现。
+ */
+
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { SelectionTray } from '../SelectionTray'
+import { useAppStore } from '@/stores/app-store'
+import type { PictogramEntry } from '@/types'
+
+// ── dnd-kit 存根 ──────────────────────────────────────────────────────────── //
+// jsdom 不支持 PointerEvent / CSS transforms，直接将拖拽容器替换为透传包裹。
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  closestCenter: vi.fn(),
+  PointerSensor: class {},
+  TouchSensor: class {},
+  useSensor: vi.fn(),
+  useSensors: vi.fn(() => []),
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  horizontalListSortingStrategy: {},
+  useSortable: vi.fn(() => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  })),
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: vi.fn(() => '') } },
+}))
+
+// ── 测试辅助 ──────────────────────────────────────────────────────────────── //
+
+function makePictogram(overrides: Partial<PictogramEntry> = {}): PictogramEntry {
+  return {
+    id: 'water',
+    imageUrl: 'https://example.com/water.png',
+    labels: { zh: ['喝水'], en: ['water'] },
+    categoryId: 'food',
+    synonyms: [],
+    disambiguationHints: {},
+    usageCount: 0,
+    ...overrides,
+  }
+}
+
+// ── 测试套件 ──────────────────────────────────────────────────────────────── //
+
+describe('SelectionTray', () => {
+  beforeEach(() => {
+    // 每个测试前重置 store 到干净初始状态
+    useAppStore.setState({
+      selectedPictograms: [],
+      isGenerating: false,
+      showCandidatePanel: false,
+    })
+  })
+
+  afterEach(() => {
+    // 清理 DOM，防止测试间污染（globals: false 时需要手动调用）
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('空状态下渲染图片序列占位区域', () => {
+    render(<SelectionTray />)
+    expect(screen.getByLabelText('图片序列')).toBeInTheDocument()
+  })
+
+  it('渲染已选图片的中文标签', () => {
+    useAppStore.setState({
+      selectedPictograms: [
+        makePictogram({ id: 'water', labels: { zh: ['喝水'], en: ['water'] } }),
+        makePictogram({ id: 'doctor', labels: { zh: ['医生'], en: ['doctor'] }, categoryId: 'people' }),
+      ],
+    })
+
+    render(<SelectionTray />)
+
+    expect(screen.getByText('喝水')).toBeInTheDocument()
+    expect(screen.getByText('医生')).toBeInTheDocument()
+  })
+
+  it('点击"清空"后 selectedPictograms 变为空数组', () => {
+    useAppStore.setState({
+      selectedPictograms: [
+        makePictogram({ id: 'water', labels: { zh: ['喝水'], en: ['water'] } }),
+      ],
+    })
+
+    render(<SelectionTray />)
+    fireEvent.click(screen.getByRole('button', { name: /清空/ }))
+
+    expect(useAppStore.getState().selectedPictograms).toHaveLength(0)
+  })
+
+  it('点击单项移除按钮后该图片从序列中删除', () => {
+    useAppStore.setState({
+      selectedPictograms: [
+        makePictogram({ id: 'water', labels: { zh: ['喝水'], en: ['water'] } }),
+        makePictogram({ id: 'doctor', labels: { zh: ['医生'], en: ['doctor'] } }),
+      ],
+    })
+
+    render(<SelectionTray />)
+    fireEvent.click(screen.getByLabelText('移除 喝水'))
+
+    const remaining = useAppStore.getState().selectedPictograms
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]?.id).toBe('doctor')
+  })
+
+  it('"说"按钮在生成中时处于禁用态', () => {
+    useAppStore.setState({
+      selectedPictograms: [
+        makePictogram({ id: 'water', labels: { zh: ['喝水'], en: ['water'] } }),
+      ],
+      isGenerating: true,
+    })
+
+    render(<SelectionTray />)
+
+    expect(screen.getByRole('button', { name: /生成中/ })).toBeDisabled()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,11 +12,21 @@ export default defineConfig({
   test: {
     globals: false,
     environment: 'node',
-    include: ['src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+    // 组件测试文件（.tsx）使用 jsdom 环境；纯工具函数测试保持 node 环境
+    environmentMatchGlobs: [
+      ['src/**/*.test.tsx', 'jsdom'],
+    ],
+    setupFiles: ['./vitest.setup.ts'],
+    include: [
+      'src/**/__tests__/**/*.test.ts',
+      'src/**/__tests__/**/*.test.tsx',
+      'src/**/*.test.ts',
+      'src/**/*.test.tsx',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      include: ['src/utils/**/*.ts'],
+      include: ['src/utils/**/*.ts', 'src/components/**/*.tsx'],
       exclude: ['src/utils/arasaac-provider.ts'],
       thresholds: { lines: 70, functions: 70 },
     },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'


### PR DESCRIPTION
## Summary

This PR improves project decision navigation for contributors and maintainers.

Changes:
- Add \`docs/decision-index.md\` as a lightweight index of current product and architecture decisions
- Add \`docs/ADR-001-receiver-data-model.md\` to formalize the receiver record decision referenced by issue #26 (two-phase write lifecycle, \`ReceiverCorrection\` table, no parallel \`ReceiverTranscript\` type)
- Link the decision index from both \`README.md\` and \`README_cn.md\`
- Organize key GitHub issues with status labels (\`status: decision-made\`, \`status: needs-design\`, \`status: ready-to-implement\`, \`status: needs-verification\`)
- Update 6 high-priority issue bodies with a \`## Status\` block that links to the current decision comment

## Notes

Issue bodies remain the source of truth for current decisions.
Issue comments preserve the historical discussion.
\`docs/decision-index.md\` is only a navigation index and should not duplicate full decision content.

## Functional impact

No runtime or product code changes.
Documentation and GitHub issue organization only.