### PR TITLE
docs: add community links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Tuyujia is a picture-based assisted communication app for people with aphasia an
 
 The project currently uses `Next.js + React 19 + TypeScript`, with `Dexie` for local `IndexedDB` data. AI requests are routed through the Next.js backend under `app/api`, so the frontend no longer stores any API keys or tokens.
 
+## Join the Community
+
+PicInterpreter welcomes code, documentation, testing, design, accessibility, AAC, rehabilitation, and real-world caregiver feedback.
+
+- [Bilingual community recruitment post](docs/community-recruitment-full-bilingual.md)
+- [Short version for social platforms](docs/community-recruitment-social-short-bilingual.md)
+- [Short version for developer communities](docs/community-recruitment-developer-short-bilingual.md)
+- [Good first issues](https://github.com/picinterpreter/picinterpreter/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
+
 ## Core Features
 
 - Expression mode: browse picture cards by category, compose an expression, generate candidate sentences, and play them aloud.

--- a/README_cn.md
+++ b/README_cn.md
@@ -5,6 +5,15 @@
 
 项目当前采用 `Next.js + React 19 + TypeScript` 构建，使用 `Dexie` 管理本地 `IndexedDB` 数据。AI 相关请求统一通过 Next.js 后端 `app/api` 转发，前端不再保存任何 API Key 或 Token。
 
+## 加入社区
+
+图语家欢迎代码、文档、测试、设计、无障碍、AAC、康复专业和真实照护场景反馈等各种形式的贡献。
+
+- [双语社区招募完整版](docs/community-recruitment-full-bilingual.md)
+- [一般自媒体短版](docs/community-recruitment-social-short-bilingual.md)
+- [开发者社区短版](docs/community-recruitment-developer-short-bilingual.md)
+- [Good first issues](https://github.com/picinterpreter/picinterpreter/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
+
 ## 核心功能
 
 - 表达模式：按分类浏览图片卡片，拼接表达内容，生成候选句子并语音播报。


### PR DESCRIPTION
## Summary\n\n- Add a small Join the Community section to README.md and README_cn.md\n- Link to the full bilingual recruitment post, social short version, developer short version, and good first issues\n- Keep the README change intentionally small instead of reviving the older conflicting README rewrite\n\n## Testing\n\n- Documentation-only change; not run