### PR TITLE
docs: add AAC reference inventory

### DIFF
--- a/docs/aac-reference-inventory.md
+++ b/docs/aac-reference-inventory.md
@@ -1,0 +1,227 @@
+# AAC Reference Inventory
+
+This document records the AAC reference materials downloaded for Tuyujia's core pictogram library research.
+
+The downloaded source files are kept outside the repository at:
+
+```text
+D:/used-by-codex/aac-core-sources
+```
+
+This repository should keep only the **inventory, source links, download notes, intended use, and licensing boundaries**. Do not commit third-party PDFs, symbol archives, or large board JSON files into the app repository unless their licenses and redistribution terms are explicitly reviewed.
+
+## Why The Raw Files Are Not Committed
+
+| Reason | Explanation |
+|---|---|
+| License safety | Several materials are CC BY-NC-SA, PDF handouts, or third-party symbol metadata. Keeping raw files out of the code repo avoids accidentally redistributing assets without review. |
+| Repository size | Some board JSON files are several MB each, and PDF/image assets will grow quickly. |
+| Source-of-truth clarity | The app should use curated seed data, not raw downloaded third-party archives. |
+| Future hosting flexibility | If raw references need to be shared, use a release artifact, cloud storage, or a separate research archive with explicit license notes. |
+
+## Downloaded Local Archive
+
+Local archive root:
+
+```text
+D:/used-by-codex/aac-core-sources
+```
+
+### AsTeRICS AAC Data
+
+Source: https://github.com/asterics/Asterics-AAC-Data
+
+Local folder:
+
+```text
+D:/used-by-codex/aac-core-sources/asterics
+```
+
+| Local file | Approx. size | Extracted scope | Intended use |
+|---|---:|---|---|
+| `quick-core-24.grd.json` | 864 KB | 50 grids, 628 unique labels | Minimal core vocabulary / small grid reference |
+| `quick-core-40.grd.json` | 1.8 MB | 64 grids, 1,669 unique labels | Medium grid vocabulary reference |
+| `quick-core-60.grd.json` | 2.0 MB | 62 grids, 2,004 unique labels | Larger core vocabulary reference |
+| `quick-core-84.grd.json` | 3.6 MB | 78 grids, 3,877 unique labels | Large grid vocabulary reference |
+| `communikate-20_EN.grd.json` | 1.8 MB | 97 grids, 1,162 unique labels | Small-grid communicator reference |
+| `Global-Core_Communicator_ARASAAC_EN.grd.json` | 2.9 MB | 54 grids, 799 unique labels | ARASAAC global-core communicator reference |
+| `communication_hospital.grd.json` | 6.1 MB | 67 grids, 864 unique labels | Hospital / ICU / symptom communication reference |
+
+License boundary:
+
+- AsTeRICS AAC Data README states that source code is AGPL-3.0.
+- Documentation and communication grids are generally CC BY-NC-SA 4.0 unless another license is mentioned in a grid's `info.json`.
+- Treat this as a reference source until each imported item is reviewed.
+
+### Extracted AsTeRICS Labels
+
+Local file:
+
+```text
+D:/used-by-codex/aac-core-sources/metadata/asterics-labels.csv
+```
+
+Rows: 12,140.
+
+Generated from all downloaded AsTeRICS `.grd.json` files. Columns include source file, grid label, row, column, English label, image URL, image author, and action types.
+
+Intended use:
+
+- Candidate vocabulary review.
+- Board structure analysis.
+- Gap analysis for the first offline core library.
+- Not a direct product import without license review.
+
+### Widgit Bedside Messages
+
+Source page: https://widgit-health.com/downloads/bedside-messages.htm
+
+Local folder:
+
+```text
+D:/used-by-codex/aac-core-sources/widgit
+```
+
+| Local file | Intended use |
+|---|---|
+| `Bedside-Messages-Mandarin-A4.pdf` | Mandarin bedside / hospital phrase reference |
+| `Bedside-Messages-Cantonese-A4.pdf` | Cantonese bedside / hospital phrase reference |
+
+License boundary:
+
+- These are PDF/visual materials, not machine-readable vocabularies.
+- Use them for manual phrase extraction and scenario coverage.
+- Do not copy symbols or layouts into the product without checking Widgit's terms.
+
+### Lingraphica Communication Boards
+
+Source page: https://lingraphica.com/free-communication-boards/
+
+Local folder:
+
+```text
+D:/used-by-codex/aac-core-sources/lingraphica
+```
+
+| Local file | Intended use |
+|---|---|
+| `Daily-Activities-Communication-Board.pdf` | Daily activity vocabulary and board layout reference |
+| `ICU-Communication-Board.pdf` | ICU / hospital communication reference |
+| `Pain-Scale-Communication-Board.pdf` | Pain scale reference |
+| `Simple-Communication-Board.pdf` | Small/simple communication board reference |
+| `Conversational-Phrases-Communication-Board.pdf` | Conversation phrase reference |
+| `Emergency-Responder-Comm-Board.pdf` | Emergency response communication reference |
+
+License boundary:
+
+- Use as scenario and board-pattern references.
+- Do not copy symbols or complete board layouts into seed data without license review.
+- PDF content should be manually reviewed before becoming test samples.
+
+### Mulberry Symbols
+
+Source: https://github.com/mulberrysymbols/mulberry-symbols
+
+Local file:
+
+```text
+D:/used-by-codex/aac-core-sources/metadata/mulberry-symbol-info.csv
+```
+
+Rows: 3,436.
+
+Intended use:
+
+- Compare symbol categories, labels, tags, and grammar metadata.
+- Possible alternate symbol source after license review.
+- Useful for designing pictogram metadata.
+
+License boundary:
+
+- Do not import images or metadata into product seed data until license and attribution requirements are reviewed.
+
+### Chinese AAC Clinical Study
+
+Source article: https://trialsjournal.biomedcentral.com/articles/10.1186/s13063-021-05799-0
+
+Local file:
+
+```text
+D:/used-by-codex/aac-core-sources/research/Huang_2021_AAC_post_stroke_aphasia_trial_protocol.pdf
+```
+
+Intended use:
+
+- Chinese post-stroke aphasia AAC context.
+- Clinical vocabulary category reference.
+- Evidence for categories such as vegetables/fruits, daily items, actions, body parts, relatives, and medical staff.
+
+License boundary:
+
+- This is a research paper, not a structured vocabulary file.
+- Use for clinical category evidence and manual review.
+
+## Local Private / User-Provided AAC Exports
+
+These files exist locally but are not copied into the archive or repository because they may include private personal data:
+
+| Local file | Intended use |
+|---|---|
+| `D:/PicInterpreter/export/cboard-all2026-03-08_16-33-14-boardsset board.json` | CBoard structure analysis |
+| `D:/PicInterpreter/export/cboard-export2026-03-08_16-32-12-boardsset board.json` | User daily board structure analysis; contains private names/photos |
+| `D:/PicInterpreter/export/openboard2026-03-08_16-32-54-日常使用黄炳灿制作 board.obf` | OBF import compatibility analysis |
+
+Boundary:
+
+- Use for structure only.
+- Do not publish private names, photos, or user-specific locations in seed data.
+
+## Not Downloaded / Reference Only
+
+| Source | Link | Reason |
+|---|---|---|
+| Taiwanese Mandarin AAC core vocabulary study | https://www.tandfonline.com/doi/abs/10.1080/07434618.2023.2199855 | Full 100-word list was not found as a public structured download. |
+| Mandarin AphasiaBank core lexicon analysis | https://pubmed.ncbi.nlm.nih.gov/36866943/ | Research abstract/reference only; not an AAC seed vocabulary download. |
+| PRC-Saltillo vocabularies | https://prc-saltillo.com/vocabularies | Commercial vocabulary system; use as product-pattern reference only. |
+| Communication Journey: Aphasia | https://prc-saltillo.com/vocabularies/communication-journey | Commercial aphasia vocabulary; do not copy content without permission. |
+| Proloquo2Go / Crescendo | https://www.assistiveware.com/products/proloquo2go | Commercial vocabulary; use as pattern reference only. |
+| TD Snap Core First | https://www.tobiidynavox.com/products/td-snap | Commercial vocabulary; use as pattern reference only. |
+| TouchChat / WordPower | https://touchchatapp.com/ | Commercial vocabulary; use as pattern reference only. |
+| LAMP Words for Life | https://aacapps.com/lamp/ | Commercial vocabulary; use as motor-planning / stable-layout reference only. |
+| Avaz AAC | https://www.avazapp.com/ | Commercial AAC product; use as onboarding/category reference only. |
+| ARASAAC full keyword database | https://arasaac.org/ | No stable full batch keyword download was found. Use candidate word -> API search -> metadata cache -> manual review. |
+
+## Recommended Product Workflow
+
+Create a working spreadsheet with these columns:
+
+```text
+source
+source_file
+source_label
+suggested_zh
+category
+core_or_fringe
+must_offline
+image_source
+license
+reuse_level
+notes
+```
+
+Recommended extraction order:
+
+1. AsTeRICS Quick Core 24 / 40 / 60.
+2. ARASAAC Global-Core Communicator.
+3. AsTeRICS Communication in hospital.
+4. Widgit Mandarin / Cantonese Bedside Messages.
+5. Lingraphica ICU / pain scale / emergency / daily boards.
+6. Chinese clinical study categories.
+7. Local CBoard structures.
+8. Mulberry metadata for category/tag comparison.
+
+## Product Boundary
+
+The offline core pictogram library should be derived from mature AAC vocabularies, open AAC boards, ARASAAC / AsTeRICS / CBoard structures, and clinical vocabulary references.
+
+Receiver fixture samples should be used for coverage validation and gap detection only. They should not become the primary source for defining the core library.

--- a/docs/receiver-fixture-samples-evidence.md
+++ b/docs/receiver-fixture-samples-evidence.md
@@ -1,0 +1,153 @@
+# Receiver Fixture Samples With Evidence Tags
+
+This document provides evidence-tagged Chinese test samples for Tuyujia's receiver flow:
+
+```text
+caregiver speech/text -> normalized text -> tokenization -> pictogram sequence -> caregiver correction
+```
+
+The samples are **not copied as a phrasebook** from any single source. They are adapted Chinese caregiver utterances based on public aphasia communication guidance, AAC hospital communication boards, open AAC board datasets, local CBoard export categories, and Chinese clinical AAC vocabulary categories.
+
+## Evidence Tags
+
+| Tag | Meaning | Source Type |
+|---|---|---|
+| `WIDGIT_BEDSIDE` | Bedside messages for people who cannot speak in hospital settings | Research-backed hospital communication message set |
+| `ASTERICS_HOSPITAL` | Hospital-context AAC communicator content and structure | Open AAC board/communicator dataset |
+| `LINGRAPHICA_BOARD` | Free AAC communication boards, ICU/pain/daily communication patterns | Public AAC board resources |
+| `CHINA_RCT_WORDS` | Chinese post-stroke aphasia AAC study vocabulary categories | Chinese clinical research categories |
+| `SCA_APHASIA` | Supported conversation strategies: yes/no, choices, confirmation, keywords | Aphasia communication method |
+| `LOCAL_CBOARD_EXPORT` | Categories and board structure extracted from local CBoard exports | Product owner-provided AAC export |
+| `AAC_PRODUCT_PATTERN` | Core/fringe, quick phrases, topic board patterns from mature AAC products | Product pattern only, not copied content |
+| `SYNTHETIC_CN_CARE` | Chinese caregiver utterance generated from the above evidence patterns | Adapted test wording |
+
+## How To Use
+
+For each sample, record:
+
+```text
+Input:
+Actual pictogram sequence:
+Expected pictogram sequence:
+Failure type: tokenization / missing image / wrong semantic match / duplicate token / wrong order / UI correction needed
+Pass: yes / no
+Notes:
+```
+
+The expected sequence is a **testing target**, not a fixed UI prescription. Caregivers may still correct the final sequence.
+
+## Samples
+
+| ID | Scenario | Caregiver utterance | Expected pictogram sequence | Evidence tags | Test focus |
+|---:|---|---|---|---|---|
+| 1 | Basic need | 你想喝水吗？ | 你 / 想要 / 喝水 / 吗 | `LINGRAPHICA_BOARD`, `SCA_APHASIA`, `SYNTHETIC_CN_CARE` | yes/no question |
+| 2 | Basic need | 你想喝水还是喝汤？ | 你 / 想要 / 喝水 / 还是 / 喝汤 | `SCA_APHASIA`, `LOCAL_CBOARD_EXPORT` | binary choice |
+| 3 | Basic need | 你饿了吗？ | 你 / 饿 / 吗 | `LINGRAPHICA_BOARD`, `CHINA_RCT_WORDS` | simple symptom/need |
+| 4 | Basic need | 要不要再吃一点？ | 要不要 / 再 / 吃 / 一点 | `SCA_APHASIA`, `AAC_PRODUCT_PATTERN` | common caregiver wording |
+| 5 | Basic need | 先喝水，再吃药。 | 先 / 喝水 / 再 / 吃药 | `ASTERICS_HOSPITAL`, `SYNTHETIC_CN_CARE` | sequence words |
+| 6 | Food | 你还要不要吃苹果？ | 你 / 还要 / 吃 / 苹果 / 吗 | `CHINA_RCT_WORDS`, `LOCAL_CBOARD_EXPORT` | food object matching |
+| 7 | Food | 这杯水太热吗？ | 水 / 热 / 吗 | `LINGRAPHICA_BOARD`, `LOCAL_CBOARD_EXPORT` | descriptor matching |
+| 8 | Food | 你吃饱了吗？ | 你 / 吃饱 / 吗 | `SCA_APHASIA`, `SYNTHETIC_CN_CARE` | phrase protection |
+| 9 | Food | 米饭吃一点，好不好？ | 米饭 / 吃 / 一点 / 好不好 | `CHINA_RCT_WORDS`, `LOCAL_CBOARD_EXPORT` | food/action phrase |
+| 10 | Food | 你想吃水果还是面包？ | 你 / 想要 / 水果 / 还是 / 面包 | `CHINA_RCT_WORDS`, `SCA_APHASIA` | choice and category |
+| 11 | Toilet | 你要去厕所吗？ | 你 / 要 / 去 / 厕所 / 吗 | `LINGRAPHICA_BOARD`, `ASTERICS_HOSPITAL` | daily care need |
+| 12 | Toilet | 现在要换尿片吗？ | 现在 / 换 / 尿片 / 吗 | `WIDGIT_BEDSIDE`, `SYNTHETIC_CN_CARE` | care activity |
+| 13 | Hygiene | 要不要洗澡？ | 要不要 / 洗澡 | `LOCAL_CBOARD_EXPORT`, `ASTERICS_HOSPITAL` | daily activity |
+| 14 | Hygiene | 先刷牙再睡觉。 | 先 / 刷牙 / 再 / 睡觉 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | action order |
+| 15 | Hygiene | 衣服湿了，要换衣服。 | 衣服 / 湿 / 换 / 衣服 | `LOCAL_CBOARD_EXPORT`, `AAC_PRODUCT_PATTERN` | repeated noun handling |
+| 16 | Hygiene | 你要洗脸吗？ | 你 / 要 / 洗脸 / 吗 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | hygiene board coverage |
+| 17 | Body / pain | 你现在痛不痛？ | 你 / 现在 / 痛 / 不痛 | `LINGRAPHICA_BOARD`, `SCA_APHASIA` | yes/no pain question |
+| 18 | Body / pain | 是头痛还是肚子痛？ | 头 / 痛 / 还是 / 肚子 / 痛 | `LINGRAPHICA_BOARD`, `CHINA_RCT_WORDS` | body-part choice |
+| 19 | Body / pain | 你肚子不舒服吗？ | 你 / 肚子 / 不舒服 / 吗 | `ASTERICS_HOSPITAL`, `LOCAL_CBOARD_EXPORT` | discomfort phrase |
+| 20 | Body / pain | 左手痛还是右手痛？ | 左手 / 痛 / 还是 / 右手 / 痛 | `CHINA_RCT_WORDS`, `SCA_APHASIA` | body side distinction |
+| 21 | Body / pain | 这里痛吗？ | 这里 / 痛 / 吗 | `LINGRAPHICA_BOARD`, `SCA_APHASIA` | deictic expression |
+| 22 | Body / pain | 痛是一点点还是很痛？ | 痛 / 一点点 / 还是 / 很痛 | `LINGRAPHICA_BOARD`, `WIDGIT_BEDSIDE` | pain intensity |
+| 23 | Symptoms | 你是不是想吐？ | 你 / 想吐 / 吗 | `ASTERICS_HOSPITAL`, `LINGRAPHICA_BOARD` | symptom matching |
+| 24 | Symptoms | 你头晕吗？ | 你 / 头晕 / 吗 | `ASTERICS_HOSPITAL`, `SYNTHETIC_CN_CARE` | symptom vocabulary |
+| 25 | Symptoms | 你冷不冷？ | 你 / 冷 / 不冷 | `WIDGIT_BEDSIDE`, `LINGRAPHICA_BOARD` | feeling/temperature |
+| 26 | Symptoms | 你热不热？ | 你 / 热 / 不热 | `WIDGIT_BEDSIDE`, `LINGRAPHICA_BOARD` | feeling/temperature |
+| 27 | Medical | 现在该吃药了。 | 现在 / 吃药 | `ASTERICS_HOSPITAL`, `CHINA_RCT_WORDS` | medical routine |
+| 28 | Medical | 等一下去医院。 | 等一下 / 去 / 医院 | `ASTERICS_HOSPITAL`, `LOCAL_CBOARD_EXPORT` | place/time |
+| 29 | Medical | 医生要给你检查。 | 医生 / 检查 / 你 | `ASTERICS_HOSPITAL`, `CHINA_RCT_WORDS` | medical role/action |
+| 30 | Medical | 护士等一下过来。 | 护士 / 等一下 / 来 | `ASTERICS_HOSPITAL`, `CHINA_RCT_WORDS` | role/time/action |
+| 31 | Medical | 今天要复查。 | 今天 / 复查 | `CHINA_RCT_WORDS`, `SYNTHETIC_CN_CARE` | medical phrase |
+| 32 | Medical | 要不要量血压？ | 要不要 / 量血压 | `ASTERICS_HOSPITAL`, `SYNTHETIC_CN_CARE` | procedure vocabulary |
+| 33 | Medical | 我帮你叫护士，好吗？ | 我 / 帮你 / 叫 / 护士 / 好吗 | `WIDGIT_BEDSIDE`, `ASTERICS_HOSPITAL` | request for staff |
+| 34 | Medical | 要不要叫医生？ | 要不要 / 叫 / 医生 | `WIDGIT_BEDSIDE`, `ASTERICS_HOSPITAL` | request for staff |
+| 35 | Rest | 你要睡觉了吗？ | 你 / 要 / 睡觉 / 吗 | `LOCAL_CBOARD_EXPORT`, `AAC_PRODUCT_PATTERN` | daily action |
+| 36 | Rest | 先休息一下。 | 先 / 休息 | `SYNTHETIC_CN_CARE`, `AAC_PRODUCT_PATTERN` | short command |
+| 37 | Rest | 你累了吗？ | 你 / 累 / 吗 | `WIDGIT_BEDSIDE`, `LINGRAPHICA_BOARD` | feeling |
+| 38 | Rest | 灯关掉，好不好？ | 关灯 / 好不好 | `WIDGIT_BEDSIDE`, `SYNTHETIC_CN_CARE` | environment request |
+| 39 | Position | 要不要坐起来？ | 要不要 / 坐起来 | `WIDGIT_BEDSIDE`, `LINGRAPHICA_BOARD` | positioning |
+| 40 | Position | 要不要躺下？ | 要不要 / 躺下 | `WIDGIT_BEDSIDE`, `LINGRAPHICA_BOARD` | positioning |
+| 41 | Position | 枕头高一点吗？ | 枕头 / 高 / 一点 / 吗 | `WIDGIT_BEDSIDE`, `SYNTHETIC_CN_CARE` | bedside comfort |
+| 42 | Position | 被子要不要盖上？ | 被子 / 要不要 / 盖上 | `WIDGIT_BEDSIDE`, `SYNTHETIC_CN_CARE` | bedside comfort |
+| 43 | Outing | 我们等一下出门。 | 我们 / 等一下 / 出门 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | future event |
+| 44 | Outing | 今晚不回家吃饭。 | 今晚 / 不 / 回家 / 吃饭 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | negation and duplicate prevention |
+| 45 | Outing | 明天去动物园玩。 | 明天 / 去 / 动物园 / 玩 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | phrase protection |
+| 46 | Outing | 现在回家。 | 现在 / 回家 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | place/action |
+| 47 | Outing | 要坐车还是走路？ | 坐车 / 还是 / 走路 | `LOCAL_CBOARD_EXPORT`, `SCA_APHASIA` | transport choice |
+| 48 | Outing | 等一下去公园。 | 等一下 / 去 / 公园 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | place matching |
+| 49 | Emotion | 你开心吗？ | 你 / 开心 / 吗 | `LOCAL_CBOARD_EXPORT`, `SCA_APHASIA` | emotion matching |
+| 50 | Emotion | 你是不是害怕？ | 你 / 害怕 / 吗 | `WIDGIT_BEDSIDE`, `LOCAL_CBOARD_EXPORT` | emotion phrase |
+| 51 | Emotion | 你生气了吗？ | 你 / 生气 / 吗 | `LOCAL_CBOARD_EXPORT`, `SCA_APHASIA` | emotion phrase |
+| 52 | Emotion | 你是不是不舒服？ | 你 / 不舒服 / 吗 | `WIDGIT_BEDSIDE`, `ASTERICS_HOSPITAL` | discomfort |
+| 53 | Emotion | 你想一个人安静一下吗？ | 你 / 想要 / 一个人 / 安静 / 吗 | `WIDGIT_BEDSIDE`, `SYNTHETIC_CN_CARE` | emotional need |
+| 54 | Emotion | 你想见家人吗？ | 你 / 想要 / 见 / 家人 / 吗 | `WIDGIT_BEDSIDE`, `CHINA_RCT_WORDS` | social need |
+| 55 | Confirmation | 是这个吗？ | 是 / 这个 / 吗 | `SCA_APHASIA`, `AAC_PRODUCT_PATTERN` | confirmation |
+| 56 | Confirmation | 不是这个，对吗？ | 不是 / 这个 / 对吗 | `SCA_APHASIA`, `SYNTHETIC_CN_CARE` | negated confirmation |
+| 57 | Confirmation | 我理解对了吗？ | 我 / 理解 / 对 / 吗 | `SCA_APHASIA`, `SYNTHETIC_CN_CARE` | repair loop |
+| 58 | Confirmation | 你是想喝水吗？ | 你 / 想要 / 喝水 / 吗 | `SCA_APHASIA`, `LINGRAPHICA_BOARD` | confirming inferred intent |
+| 59 | Confirmation | 你是想出去吗？ | 你 / 想要 / 出去 / 吗 | `SCA_APHASIA`, `SYNTHETIC_CN_CARE` | confirming inferred intent |
+| 60 | Confirmation | 你要这个还是那个？ | 你 / 要 / 这个 / 还是 / 那个 | `SCA_APHASIA`, `AAC_PRODUCT_PATTERN` | choice repair |
+| 61 | Time | 现在吃饭。 | 现在 / 吃饭 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | time/action |
+| 62 | Time | 等一下洗澡。 | 等一下 / 洗澡 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | time/action |
+| 63 | Time | 明天去医院。 | 明天 / 去 / 医院 | `ASTERICS_HOSPITAL`, `LOCAL_CBOARD_EXPORT` | time/place |
+| 64 | Time | 今天不用出门。 | 今天 / 不用 / 出门 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | negation |
+| 65 | Time | 晚上再看电视。 | 晚上 / 再 / 看电视 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | entertainment/time |
+| 66 | Time | 吃完饭再睡觉。 | 吃完饭 / 再 / 睡觉 | `SYNTHETIC_CN_CARE`, `LOCAL_CBOARD_EXPORT` | phrase protection |
+| 67 | Family | 要不要打电话给妈妈？ | 要不要 / 打电话 / 妈妈 | `CHINA_RCT_WORDS`, `LOCAL_CBOARD_EXPORT` | family role |
+| 68 | Family | 爸爸等一下来看你。 | 爸爸 / 等一下 / 来 / 看你 | `CHINA_RCT_WORDS`, `SYNTHETIC_CN_CARE` | family role/time |
+| 69 | Family | 谁来看你？ | 谁 / 来 / 看你 | `SCA_APHASIA`, `CHINA_RCT_WORDS` | question word |
+| 70 | Family | 你想找谁？ | 你 / 想要 / 找 / 谁 | `SCA_APHASIA`, `CHINA_RCT_WORDS` | question word |
+| 71 | Family | 要不要视频通话？ | 要不要 / 视频通话 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | technology board |
+| 72 | Family | 要不要给家里人发消息？ | 要不要 / 家人 / 发消息 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | family + technology |
+| 73 | Activity | 要不要看电视？ | 要不要 / 看电视 | `LOCAL_CBOARD_EXPORT`, `AAC_PRODUCT_PATTERN` | activity |
+| 74 | Activity | 要不要听音乐？ | 要不要 / 听音乐 | `LOCAL_CBOARD_EXPORT`, `AAC_PRODUCT_PATTERN` | activity |
+| 75 | Activity | 要不要出去走走？ | 要不要 / 出去 / 走走 | `LOCAL_CBOARD_EXPORT`, `SYNTHETIC_CN_CARE` | phrase action |
+| 76 | Activity | 你想玩玩具吗？ | 你 / 想要 / 玩 / 玩具 / 吗 | `LOCAL_CBOARD_EXPORT`, `AAC_PRODUCT_PATTERN` | linked PictureSet |
+| 77 | Activity | 要不要画画？ | 要不要 / 画画 | `ASTERICS_HOSPITAL`, `LOCAL_CBOARD_EXPORT` | activity board |
+| 78 | Activity | 你想看照片吗？ | 你 / 想要 / 看 / 照片 / 吗 | `AAC_PRODUCT_PATTERN`, `SYNTHETIC_CN_CARE` | private photo support |
+| 79 | Safety | 不要动，等一下。 | 不要 / 动 / 等一下 | `WIDGIT_BEDSIDE`, `SYNTHETIC_CN_CARE` | safety command |
+| 80 | Safety | 有危险，先停下来。 | 危险 / 先 / 停下来 | `WIDGIT_BEDSIDE`, `AAC_PRODUCT_PATTERN` | emergency/safety |
+
+## Coverage Checklist
+
+| Coverage Area | Sample IDs |
+|---|---|
+| Yes/no questions | 1, 7, 11, 13, 17, 21, 24, 25, 26, 35, 37, 49-52, 55-60 |
+| Binary choices | 2, 10, 18, 20, 22, 47, 60 |
+| Sequence words | 5, 14, 44, 54, 66 |
+| Negation | 44, 56, 64, 79 |
+| Pain and symptoms | 17-26 |
+| Medical/hospital | 27-34, 63 |
+| Position and bedside comfort | 39-42 |
+| Family/social | 54, 67-72 |
+| Local CBoard category coverage | food, drinks, body, people, emotions, hygiene, actions, places, time, transport, toys, technology |
+
+## Source Notes
+
+- `WIDGIT_BEDSIDE`: Widgit Bedside Messages are based on research into messages people may need when unable to speak in bedside / hospital contexts.
+- `ASTERICS_HOSPITAL`: AsTeRICS AAC Data includes `Communication in hospital`, `Quick Core`, and `Global-Core Communicator ARASAAC` examples.
+- `LINGRAPHICA_BOARD`: Lingraphica publishes free AAC communication boards and aphasia communication resources, including hospital/ICU/pain-oriented materials.
+- `CHINA_RCT_WORDS`: A Chinese post-stroke aphasia AAC clinical study used high-frequency categories such as vegetables/fruits, daily items, actions, body parts, relatives, and medical staff.
+- `SCA_APHASIA`: Supported Conversation for Adults with Aphasia emphasizes short utterances, written/visual keywords, confirmation, yes/no, and choice-based communication.
+- `LOCAL_CBOARD_EXPORT`: Product-owner-provided CBoard exports include categories such as quickChat, food, drinks, body, emotions, hygiene, actions, places, time, transport, toys, technology, questions, and descriptors.
+
+## References
+
+- Widgit Bedside Messages: https://widgit-health.com/downloads/bedside-messages.htm
+- AsTeRICS AAC Data: https://github.com/asterics/Asterics-AAC-Data
+- Lingraphica free communication boards: https://lingraphica.com/free-communication-boards/
+- Aphasia Institute Supported Conversation: https://www.aphasia.ca/communication-tools-communicative-access-sca/
+- Chinese AAC clinical study: https://pmc.ncbi.nlm.nih.gov/articles/PMC8611624/

--- a/docs/receiver-fixture-samples-evidence.md
+++ b/docs/receiver-fixture-samples-evidence.md
@@ -135,7 +135,62 @@ The expected sequence is a **testing target**, not a fixed UI prescription. Care
 | Family/social | 54, 67-72 |
 | Local CBoard category coverage | food, drinks, body, people, emotions, hygiene, actions, places, time, transport, toys, technology |
 
-## Source Notes
+## Engineering Test Notes
+
+These notes map selected samples to the matching pipeline rules they verify. The JSON fixture `fixtures/receiver-samples.json` contains the corresponding machine-executable assertions (`expectedTokens`, `matchType`, `minMatchRate`, `preSegmented`).
+
+### Rule 1 — Function words allowed to be `missing`; must not disrupt core token matching
+
+The following tokens have no pictogram and will return `matchType: missing`. This is expected. The test passes as long as the surrounding content tokens still match correctly.
+
+| Token | Applies to samples | Why missing |
+|---|---|---|
+| `吗` | 1, 3, 6, 7, 11, 13, 16, 17, 21, 24, 25, 26, 35, 37, 41, 49–54, 55–60 | Question particle, no pictogram |
+| `还是` | 2, 10, 18, 20, 22, 47, 60 | Binary choice connector, no pictogram |
+| `先` / `再` | 5, 14, 36, 65, 66 | Sequence adverbs, no pictogram |
+| `很` / `太` / `一点` | 7, 9, 41 | Degree modifiers, no pictogram |
+| `了` | 3, 66 | Aspect particle, no pictogram |
+
+**Pass criterion:** `matchRate` of the content words (excluding function words) ≥ 0.8, even if overall `matchRate` is lower.
+
+### Rule 2 — `不要` triggers NEGATION_PREFIXES guard in Strategy 4
+
+Samples #79 (`不要动，等一下`) and any token starting with `不` that is ≥ 3 characters must **not** be matched via Strategy 4 (partial/contains matching). The guard prevents semantic inversion errors such as `不开心` → `开心`.
+
+| Sample | Token | Correct path | Must NOT happen |
+|---|---|---|---|
+| #56 | `不是` | `missing` or `lexicon` | Strategy 4 partial → `是` |
+| #79 | `不要动` (if unsplit) | `missing` (no lexicon entry) | Strategy 4 partial → `要` |
+| JSON D3 | `不开心` | `lexicon → 伤心` | Strategy 4 partial → `开心` |
+| JSON F4 | `不要` (split) | `exact → 不要` | n/a (already exact) |
+
+**Pass criterion:** No token starting with `不` / `没` / `别` / `勿` / `莫` / `未` should have `matchType: partial`.
+
+### Rule 3 — Confirmation/repair loop sentences allow low `matchRate`
+
+Sample #57 (`我理解对了吗？`) and similar meta-sentences will have many `missing` tokens because abstract cognitive words (`理解`, `吗`) have no pictograms. This is expected and **not a failure**.
+
+| Sample | Expected `matchRate` | Rationale |
+|---|---|---|
+| #57 我理解对了吗？ | ~0.35–0.4 | `理解`、`了`、`吗` missing; only `我` + `对`(→有 via lexicon) match |
+| #55 是这个吗？ | ~0.3 | `是`(→有)、`这个` missing; 吗 missing |
+| #60 你要这个还是那个？ | ~0.4 | `这个`、`还是`、`那个` missing |
+
+**Pass criterion:** System does not throw; `matches` array is returned with `matchType: missing` for unrecognised tokens; overall `matchRate` may be as low as 0.2 without indicating a bug.
+
+### Rule 4 — Pain intensity words `missing` must not corrupt the `痛` match
+
+Sample #22 (`痛是一点点还是很痛？`) exercises the pain intensity vocabulary gap. The token `痛` **must** be matched as `exact` with `labelZh: 痛`. Degree modifiers (`一点点`, `很痛`) must be `missing` — they must not be mismatched to other pictograms.
+
+| Token | Expected | Must NOT |
+|---|---|---|
+| `痛` | `exact → 痛` | match `头晕` or any non-pain pictogram |
+| `一点点` | `missing` | partial-match a 2-char label unrelated to pain |
+| `很痛` | `missing` (2-char token, Strategy 4 requires ≥ 3) | partial-match `痛` label (1-char, filtered by Strategy 4) |
+
+**Pass criterion:** `matches.find(m => m.token === '痛').matchType === 'exact'` and `matches.find(m => m.token === '一点点').matchType === 'missing'`.
+
+
 
 - `WIDGIT_BEDSIDE`: Widgit Bedside Messages are based on research into messages people may need when unable to speak in bedside / hospital contexts.
 - `ASTERICS_HOSPITAL`: AsTeRICS AAC Data includes `Communication in hospital`, `Quick Core`, and `Global-Core Communicator ARASAAC` examples.

--- a/fixtures/receiver-samples.json
+++ b/fixtures/receiver-samples.json
@@ -1,0 +1,663 @@
+[
+  {
+    "id": "A1",
+    "inputText": "喝水",
+    "description": "单词直接表达需求（SCA 极短句式）。「喝水」是种子库精确标签，期望 matchRate=1.0。",
+    "evidence": [
+      { "source": "SCA", "note": "失语症患者常以单词代替完整句表达需求" },
+      { "source": "Widgit-26", "note": "Hemsley 26 critical phrases: I'm thirsty / I need a drink" },
+      { "source": "AsTeRICS-Hospital", "note": "Need_to_drink grid 核心词" }
+    ],
+    "testFocus": "单 token 精确匹配基线",
+    "expectedTokens": [
+      { "token": "喝水", "matchType": "exact", "labelZh": "喝水" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "A2",
+    "inputText": "我渴",
+    "description": "2 字极短句（我 + 状态词）。两词均在种子库，期望 matchRate=1.0。",
+    "evidence": [
+      { "source": "SCA", "note": "2 字短句是失语症患者真实表达常态" },
+      { "source": "Lingraphica-ICU", "note": "ICU 需求板块：thirsty 状态表达" },
+      { "source": "2023-Mandarin", "note": "「渴」在台湾普通话核心词频研究 100 词内" }
+    ],
+    "testFocus": "2 token 全精确匹配",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "渴", "matchType": "exact", "labelZh": "渴" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "A3",
+    "inputText": "去厕所",
+    "description": "2 字动宾结构（动词 + 地点）。两词均在种子库，期望 matchRate=1.0。",
+    "evidence": [
+      { "source": "SCA", "note": "动宾极短句式：行为 + 目标地点" },
+      { "source": "Widgit-26", "note": "Hemsley 26: I need the toilet — 最高优先级基本需求" },
+      { "source": "AsTeRICS-Hospital", "note": "Need_for_toilet grid" }
+    ],
+    "testFocus": "动宾极短句精确匹配",
+    "expectedTokens": [
+      { "token": "去", "matchType": "exact", "labelZh": "去" },
+      { "token": "厕所", "matchType": "exact", "labelZh": "厕所" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "A4",
+    "inputText": "我痛",
+    "description": "2 字极短症状句（主语 + 痛感词）。两词均在种子库，期望 matchRate=1.0。",
+    "evidence": [
+      { "source": "SCA", "note": "失语症患者高频症状表达：主语 + 核心症状词" },
+      { "source": "Widgit-26", "note": "Hemsley 26: I'm in pain / I'm uncomfortable" },
+      { "source": "AsTeRICS-Hospital", "note": "Unwell grid 核心痛感词" }
+    ],
+    "testFocus": "核心症状词精确匹配",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "痛", "matchType": "exact", "labelZh": "痛" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "A5",
+    "inputText": "不要",
+    "description": "单词快速拒绝。「不要」是种子库精确标签，否定词不拆分，期望 matchRate=1.0。",
+    "evidence": [
+      { "source": "SCA", "note": "快速拒绝/停止是 AAC 最基础需求之一" },
+      { "source": "AsTeRICS-QC24", "note": "Quick Core 24 根板：「not」位于 24 词之列" },
+      { "source": "LAMP", "note": "否定词需稳定放置，患者应能一触即达" }
+    ],
+    "testFocus": "否定复合词精确匹配（不拆成两词）",
+    "expectedTokens": [
+      { "token": "不要", "matchType": "exact", "labelZh": "不要" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "A6",
+    "inputText": "帮忙",
+    "description": "单词求助。「帮忙」是种子库精确标签，期望 matchRate=1.0。",
+    "evidence": [
+      { "source": "SCA", "note": "单词求助是 AAC 紧急沟通核心" },
+      { "source": "Widgit-26", "note": "Hemsley 26: Please call the nurse / Please call my family" },
+      { "source": "Lingraphica-ICU", "note": "ICU 板块顶层 help 按钮" }
+    ],
+    "testFocus": "求助词精确匹配",
+    "expectedTokens": [
+      { "token": "帮忙", "matchType": "exact", "labelZh": "帮忙" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "B1",
+    "inputText": "我想喝水",
+    "description": "基本需求句（主 + 情态动词 + 动词 + 宾语）。全词在种子库，期望 matchRate ≥ 0.9。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Need_to_drink grid 完整表达模式" },
+      { "source": "2023-Mandarin", "note": "「我」「想」「喝」均在 Mandarin 100 核心词内" },
+      { "source": "Lingraphica-ICU", "note": "ICU 饮水需求表达参考" }
+    ],
+    "testFocus": "基本需求句全精确匹配基线（Issue #56 ≥2 条基本需求要求）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "想", "matchType": "exact", "labelZh": "想" },
+      { "token": "喝水", "matchType": "exact", "labelZh": "喝水" }
+    ],
+    "_segmentationNote": "分词器可能产生 [我,想,喝水] 或 [我,想,喝,水]；两种路径均可精确命中",
+    "minMatchRate": 0.9
+  },
+  {
+    "id": "B2",
+    "inputText": "我要去厕所",
+    "description": "基本需求句含「要」（想的口语同义词）。验证 lexicon 路径：要→想。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Need_for_toilet grid 表达模式" },
+      { "source": "Widgit-26", "note": "Hemsley 26: I need the toilet" },
+      { "source": "SCA", "note": "「要」是失语症患者高频口语替代词" }
+    ],
+    "testFocus": "lexicon 路径：「要」→词库同义词→「想」图片（Issue #56 ≥2 条 lexicon 路径要求）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "要", "matchType": "lexicon", "labelZh": "想" },
+      { "token": "去", "matchType": "exact", "labelZh": "去" },
+      { "token": "厕所", "matchType": "exact", "labelZh": "厕所" }
+    ],
+    "minMatchRate": 0.75
+  },
+  {
+    "id": "B3",
+    "inputText": "我饿了想吃饭",
+    "description": "基本需求句含语气助词「了」和复合词「吃饭」。「了」应为 missing；测试分词器对「饿了」的处理。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Need_to_eat grid 场景" },
+      { "source": "SCA", "note": "含语气助词是真实话语常见模式" }
+    ],
+    "testFocus": "语气助词「了」missing；分词挑战（Issue #56 ≥2 条含 missing token）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "饿", "matchType": "exact", "labelZh": "饿" },
+      { "token": "了", "matchType": "missing", "labelZh": null },
+      { "token": "想", "matchType": "exact", "labelZh": "想" },
+      { "token": "吃", "matchType": "exact", "labelZh": "吃" },
+      { "token": "饭", "matchType": "missing", "labelZh": null }
+    ],
+    "_segmentationNote": "Intl.Segmenter 多数产生 [我,饿,了,想,吃,饭]；饭 在种子库无独立标签，missing",
+    "minMatchRate": 0.6
+  },
+  {
+    "id": "B4",
+    "inputText": "我想睡觉",
+    "description": "基本需求句（需要休息）。三词均在种子库，期望 matchRate=1.0。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "基本需求：rest / sleep 场景" },
+      { "source": "Lingraphica-ICU", "note": "ICU 常见需求：need to sleep" },
+      { "source": "2023-Mandarin", "note": "「睡觉」是台湾普通话核心词高频词" }
+    ],
+    "testFocus": "基本需求全精确匹配（Issue #56 ≥2 条基本需求要求）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "想", "matchType": "exact", "labelZh": "想" },
+      { "token": "睡觉", "matchType": "exact", "labelZh": "睡觉" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "B5",
+    "inputText": "帮我叫护士",
+    "description": "求助 + 人物词。「帮」通过 lexicon 路径命中「帮忙」；「叫」「护士」精确匹配。",
+    "evidence": [
+      { "source": "Widgit-26", "note": "Hemsley 26: Please call the nurse — 高优先级医院求助" },
+      { "source": "AsTeRICS-Hospital", "note": "Nurse grid / call for help 场景" },
+      { "source": "SCA", "note": "帮忙 + 人物词是 SCA 求助句式" }
+    ],
+    "testFocus": "lexicon 路径：「帮」→「帮忙」（Issue #56 lexicon 路径测试）",
+    "expectedTokens": [
+      { "token": "帮", "matchType": "lexicon", "labelZh": "帮忙" },
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "叫", "matchType": "exact", "labelZh": "叫" },
+      { "token": "护士", "matchType": "exact", "labelZh": "护士" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "C1",
+    "inputText": "我头很痛",
+    "description": "症状句含程度副词「很」。「头」「痛」精确命中；「很」为 missing。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Unwell / pain location grid" },
+      { "source": "Widgit-26", "note": "Hemsley 26: I'm in pain (location modifier)" }
+    ],
+    "testFocus": "症状双词精确匹配 + 程度副词 missing（Issue #56 ≥2 条医疗/症状场景）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "头", "matchType": "exact", "labelZh": "头" },
+      { "token": "很", "matchType": "missing", "labelZh": null },
+      { "token": "痛", "matchType": "exact", "labelZh": "痛" }
+    ],
+    "minMatchRate": 0.7
+  },
+  {
+    "id": "C2",
+    "inputText": "肚子疼",
+    "description": "腹痛短句。「肚子」精确命中；「疼」走 lexicon 路径（疼是「痛」同义词）。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Unwell / stomach pain grid" },
+      { "source": "SCA", "note": "「肚子疼」是患者高频症状短句" }
+    ],
+    "testFocus": "同义词 lexicon 路径：「疼」→词库→「痛」图片",
+    "expectedTokens": [
+      { "token": "肚子", "matchType": "exact", "labelZh": "肚子" },
+      { "token": "疼", "matchType": "lexicon", "labelZh": "痛" }
+    ],
+    "_segmentationNote": "若分词器产生 [肚子疼] 整体 token，则 Strategy 4 partial 命中「肚子」；两路径均合法",
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "C3",
+    "inputText": "我发烧了",
+    "description": "症状句含语气助词「了」。「发烧」精确命中；「了」为 missing。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Something_is_wrong / fever grid" },
+      { "source": "Lingraphica-ICU", "note": "ICU 症状：fever 是高优先级症状" }
+    ],
+    "testFocus": "症状词精确匹配 + 语气助词 missing",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "发烧", "matchType": "exact", "labelZh": "发烧" },
+      { "token": "了", "matchType": "missing", "labelZh": null }
+    ],
+    "minMatchRate": 0.6
+  },
+  {
+    "id": "C4",
+    "inputText": "我头晕",
+    "description": "症状句（头晕是脑卒中后遗症高频症状）。两词均在种子库，期望 matchRate=1.0。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Unwell / dizzy grid" },
+      { "source": "Aphasia-Best-Practice", "note": "脑卒中患者最常见主诉症状之一" }
+    ],
+    "testFocus": "症状精确匹配（Issue #56 医疗场景）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "头晕", "matchType": "exact", "labelZh": "头晕" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "C5",
+    "inputText": "我咳嗽",
+    "description": "症状句（咳嗽是常见肺部症状）。两词均在种子库，期望 matchRate=1.0。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Something_is_wrong / cough grid" }
+    ],
+    "testFocus": "症状精确匹配（Issue #56 医疗场景）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "咳嗽", "matchType": "exact", "labelZh": "咳嗽" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "C6",
+    "inputText": "我胸口疼",
+    "description": "胸痛症状句。「胸口」精确命中；「疼」走 lexicon 路径。也可测 partial 路径（若分词器产生「胸口疼」整体 token）。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Something_is_wrong / chest pain — 高优先级急症场景" },
+      { "source": "Lingraphica-ICU", "note": "ICU 胸部症状表达" }
+    ],
+    "testFocus": "exact + lexicon 混合，或 partial 路径（Issue #56 exact+partial 混合要求）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "胸口", "matchType": "exact", "labelZh": "胸口" },
+      { "token": "疼", "matchType": "lexicon", "labelZh": "痛" }
+    ],
+    "_altPath": "若分词器产生 [我, 胸口疼]，则 胸口疼 → Strategy 4 partial → 胸口",
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "C7",
+    "inputText": "我呼吸困难",
+    "description": "呼吸症状句（4 字复合词）。「呼吸困难」是种子库精确标签（4 字整体），期望 matchRate ≥ 0.8。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Something_is_wrong / breathing difficulty grid" },
+      { "source": "Lingraphica-ICU", "note": "ICU 呼吸困难是最紧急症状之一" }
+    ],
+    "testFocus": "4 字复合词整体精确匹配（分词器是否保持「呼吸困难」不拆分）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "呼吸困难", "matchType": "exact", "labelZh": "呼吸困难" }
+    ],
+    "_segmentationNote": "若分词器将「呼吸困难」拆开（呼吸/困难），则 matchRate 降至 0.33；此处验证分词器对医学复合词的处理",
+    "minMatchRate": 0.8
+  },
+  {
+    "id": "C8",
+    "inputText": "我感觉恶心",
+    "description": "症状句含认知动词「感觉」。「恶心」精确命中；「感觉」为 missing（功能词，无对应图片）。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Unwell / nausea grid" },
+      { "source": "SCA", "note": "「感觉」是患者描述主观症状的高频前缀词" }
+    ],
+    "testFocus": "症状词精确匹配 + 认知动词 missing（Issue #56 ≥2 条 missing token）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "感觉", "matchType": "missing", "labelZh": null },
+      { "token": "恶心", "matchType": "exact", "labelZh": "恶心" }
+    ],
+    "minMatchRate": 0.6
+  },
+  {
+    "id": "D1",
+    "inputText": "我很害怕",
+    "description": "情绪句含程度副词「很」。「害怕」精确命中；「很」为 missing。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Well-being / scared grid" },
+      { "source": "Widgit-26", "note": "Hemsley 26: I'm scared / I'm confused" },
+      { "source": "SCA", "note": "情绪表达是 SCA 训练核心场景" }
+    ],
+    "testFocus": "情绪词精确匹配（Issue #56 ≥1 条情绪场景）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "很", "matchType": "missing", "labelZh": null },
+      { "token": "害怕", "matchType": "exact", "labelZh": "害怕" }
+    ],
+    "minMatchRate": 0.6
+  },
+  {
+    "id": "D2",
+    "inputText": "我很难受",
+    "description": "情绪/不适句。「难受」在词库中是「痛」的同义词，走 lexicon 路径命中「痛」图片；验证「难受」有 lexicon 覆盖。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Well-being / uncomfortable grid" },
+      { "source": "SCA", "note": "「难受」是失语症患者描述综合不适的高频词" }
+    ],
+    "testFocus": "lexicon 路径：「难受」→词库同义词→「痛」图片（Issue #56 lexicon 路径）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "很", "matchType": "missing", "labelZh": null },
+      { "token": "难受", "matchType": "lexicon", "labelZh": "痛" }
+    ],
+    "_lexiconNote": "词库 lexicon.ts 中 痛.synonyms 包含「难受」，故路径为 难受→痛，而非→伤心",
+    "minMatchRate": 0.6
+  },
+  {
+    "id": "D3",
+    "inputText": "我不开心",
+    "description": "否定情绪句。关键测试：「不开心」作为整体 token 时，NEGATION_PREFIXES 守护规则必须阻止 Strategy 4 将「开心」匹配出来；正确路径是 lexicon→「伤心」。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Emotions / unhappy grid" },
+      { "source": "SCA", "note": "否定情绪表达是 SCA 高优先级场景" }
+    ],
+    "testFocus": "NEGATION_PREFIXES 守护规则验证（Issue #56 ≥1 条否定句要求）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "不开心", "matchType": "lexicon", "labelZh": "伤心" }
+    ],
+    "_negationGuard": "若分词器产生 [我,不开心]：「不开心」启动 Strategy 3 lexicon → 伤心（词库 伤心.synonyms 含「不开心」），Strategy 4 因 NEGATION_PREFIXES 被跳过，确保不会错误匹配为「开心」",
+    "_altPath": "若分词器产生 [我,不,开心]：三词均 exact 匹配，否定守护规则无需触发，minMatchRate=1.0",
+    "_pendingValidation": "需在 /debug 页面验证 Intl.Segmenter 对「不开心」的切分方式",
+    "minMatchRate": 0.6
+  },
+  {
+    "id": "E1",
+    "inputText": "我想吃饭谢谢",
+    "description": "多词组合（需求 + 礼貌词）。「饭」无独立图片标签（种子库只有「吃晚饭/早饭/午饭」），预期为 missing；其余词精确命中。",
+    "evidence": [
+      { "source": "AsTeRICS-QC24", "note": "Quick Core 24 多词组合原则：I + want + eat + (fringe word)" },
+      { "source": "SCA", "note": "礼貌词「谢谢」在 AAC 中属高频核心词" }
+    ],
+    "testFocus": "多 token 精确匹配 + 1 个 missing（饭无图）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "想", "matchType": "exact", "labelZh": "想" },
+      { "token": "吃", "matchType": "exact", "labelZh": "吃" },
+      { "token": "饭", "matchType": "missing", "labelZh": null },
+      { "token": "谢谢", "matchType": "exact", "labelZh": "谢谢" }
+    ],
+    "_segmentationNote": "分词器也可能产生 [我,想,吃饭,谢谢]；「吃饭」→ lexicon 同义词→「吃」，matchRate=1.0",
+    "minMatchRate": 0.75
+  },
+  {
+    "id": "E2",
+    "inputText": "今天我很开心",
+    "description": "时间词 + 情绪词组合。「今天」「我」「开心」精确命中；「很」为 missing（程度副词无图）。",
+    "evidence": [
+      { "source": "AsTeRICS-QC24", "note": "Quick Core 24 时间词 + 情绪词组合模式" },
+      { "source": "SCA", "note": "时间定向 + 情绪表达是 SCA 日常对话训练场景" }
+    ],
+    "testFocus": "时间词 + 情绪词精确匹配 + 程度副词 missing",
+    "expectedTokens": [
+      { "token": "今天", "matchType": "exact", "labelZh": "今天" },
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "很", "matchType": "missing", "labelZh": null },
+      { "token": "开心", "matchType": "exact", "labelZh": "开心" }
+    ],
+    "minMatchRate": 0.7
+  },
+  {
+    "id": "E3",
+    "inputText": "我头痛不舒服想吃药",
+    "description": "长多症状句（头痛 + 不舒服 + 吃药）。「头痛」走 lexicon 路径；「不」「舒服」需验证；「药」精确命中。期望 matchRate ≥ 0.75。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "多症状并发场景：pain + unwell + medication request" },
+      { "source": "Lingraphica-ICU", "note": "ICU 多症状自述场景" }
+    ],
+    "testFocus": "长句多 token 覆盖（Issue #56 exact+partial 混合场景）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "头痛", "matchType": "lexicon", "labelZh": "痛" },
+      { "token": "不", "matchType": "exact", "labelZh": "不" },
+      { "token": "舒服", "matchType": "missing", "labelZh": null },
+      { "token": "想", "matchType": "exact", "labelZh": "想" },
+      { "token": "吃", "matchType": "exact", "labelZh": "吃" },
+      { "token": "药", "matchType": "exact", "labelZh": "药" }
+    ],
+    "_lexiconNote": "词库 痛.synonyms 含「头痛」，故 头痛 → lexicon → 痛",
+    "_segmentationNote": "分词器也可能产生 [头,痛] 或 [头,痛,不舒服] 等，matchRate 可能更高",
+    "minMatchRate": 0.75
+  },
+  {
+    "id": "E4",
+    "inputText": "妈妈我肚子饿了",
+    "description": "家人称呼 + 症状句。「妈妈」在词库有条目但种子库无图，为 missing；「了」为 missing；其余精确命中。",
+    "evidence": [
+      { "source": "SCA", "note": "称呼家人 + 需求是失语症日常交流高频模式" },
+      { "source": "AsTeRICS-Hospital", "note": "Need_to_eat 场景的家庭版本" }
+    ],
+    "testFocus": "人名/称呼词 missing（Issue #56 ≥2 条含 missing token）",
+    "expectedTokens": [
+      { "token": "妈妈", "matchType": "missing", "labelZh": null },
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "肚子", "matchType": "exact", "labelZh": "肚子" },
+      { "token": "饿", "matchType": "exact", "labelZh": "饿" },
+      { "token": "了", "matchType": "missing", "labelZh": null }
+    ],
+    "_missingNote": "妈妈：词库有条目（zh: 妈妈），但种子库 pictograms.json 无对应标签 → missing；此处验证种子库覆盖缺口",
+    "_pendingValidation": "需在 /debug 验证 妈妈 是否已加入种子库",
+    "minMatchRate": 0.5
+  },
+  {
+    "id": "E5",
+    "inputText": "今天早上我发烧了还咳嗽",
+    "description": "时间词 + 两症状（发烧、咳嗽）。「了」「还」为 missing；测试多 token 覆盖能力。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "多症状并发场景：fever + cough" },
+      { "source": "SCA", "note": "时间定向 + 多症状描述是临床沟通真实场景" }
+    ],
+    "testFocus": "时间词 + 双症状词精确匹配 + 虚词 missing（Issue #56 多 token 覆盖）",
+    "expectedTokens": [
+      { "token": "今天", "matchType": "exact", "labelZh": "今天" },
+      { "token": "早上", "matchType": "exact", "labelZh": "早上" },
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "发烧", "matchType": "exact", "labelZh": "发烧" },
+      { "token": "了", "matchType": "missing", "labelZh": null },
+      { "token": "还", "matchType": "missing", "labelZh": null },
+      { "token": "咳嗽", "matchType": "exact", "labelZh": "咳嗽" }
+    ],
+    "minMatchRate": 0.65
+  },
+  {
+    "id": "E6",
+    "inputText": "帮我叫医生来",
+    "description": "求助 + 人物 + 动作。「帮」走 lexicon 路径；「叫」「医生」「来」精确命中。期望 matchRate=1.0。",
+    "evidence": [
+      { "source": "Widgit-26", "note": "Hemsley 26: Please call the doctor" },
+      { "source": "SCA", "note": "求助 + 人物 + 到来动词是 SCA 医院场景句式" },
+      { "source": "AsTeRICS-Hospital", "note": "Doctor / nurse call grid" }
+    ],
+    "testFocus": "lexicon 路径「帮→帮忙」+ 多词精确匹配（Issue #56 matchRate ≥ 0.8 基线）",
+    "expectedTokens": [
+      { "token": "帮", "matchType": "lexicon", "labelZh": "帮忙" },
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "叫", "matchType": "exact", "labelZh": "叫" },
+      { "token": "医生", "matchType": "exact", "labelZh": "医生" },
+      { "token": "来", "matchType": "exact", "labelZh": "来" }
+    ],
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "E7",
+    "inputText": "我需要休息一下",
+    "description": "「需要」走 lexicon 路径（是「想」的同义词）；「休息」精确命中；「一下」为 missing（轻声量词无图）。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Need_for_rest / 基本需求 grid" },
+      { "source": "SCA", "note": "「一下」是真实话语中常见的缓和词，无 AAC 图片" }
+    ],
+    "testFocus": "lexicon 路径「需要→想」+ missing「一下」（Issue #56 missing token 验证）",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "需要", "matchType": "lexicon", "labelZh": "想" },
+      { "token": "休息", "matchType": "exact", "labelZh": "休息" },
+      { "token": "一下", "matchType": "missing", "labelZh": null }
+    ],
+    "_lexiconNote": "词库 想.synonyms 含「需要」，故 需要 → lexicon → 想",
+    "minMatchRate": 0.7
+  },
+  {
+    "id": "P1",
+    "inputText": "我肚子疼",
+    "description": "partial 路径专项测试。使用 preSegmented 强制产生「肚子疼」整体 token，验证 Strategy 4 包含匹配：「肚子疼」(3字) 包含「肚子」(2字) → partial。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Unwell / stomach pain grid" },
+      { "source": "SCA", "note": "「肚子疼」是失语症患者常见单块表达方式" }
+    ],
+    "testFocus": "Strategy 4 包含匹配（exact + partial 混合；Issue #56 ≥3 条 exact+partial 要求）",
+    "preSegmented": ["我", "肚子疼"],
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "肚子疼", "matchType": "partial", "labelZh": "肚子" }
+    ],
+    "_partialNote": "Strategy 4：token「肚子疼」长度3，非否定前缀，包含 label「肚子」(2字) → partial 命中",
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "P2",
+    "inputText": "我胸口疼痛",
+    "description": "partial 路径专项测试。「胸口疼痛」(4字) 包含「胸口」(2字) → partial。同时测试 exact 和 partial 在同一样本中共存。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Something_is_wrong / chest pain — 高优先级急症" },
+      { "source": "Lingraphica-ICU", "note": "ICU 胸部症状最高优先级" }
+    ],
+    "testFocus": "Strategy 4 包含匹配（exact + partial 混合；Issue #56 ≥3 条 exact+partial 要求）",
+    "preSegmented": ["我", "胸口疼痛"],
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "胸口疼痛", "matchType": "partial", "labelZh": "胸口" }
+    ],
+    "_partialNote": "Strategy 4：token「胸口疼痛」长度4，非否定前缀，包含 label「胸口」(2字) → partial 命中",
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "P3",
+    "inputText": "今天头晕眼花",
+    "description": "partial 路径专项测试。「头晕眼花」(4字) 包含「头晕」(2字) → partial；「今天」精确命中。验证 exact + partial 混合。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "Unwell / dizzy grid — 脑卒中常见症状" },
+      { "source": "SCA", "note": "「头晕眼花」是患者自述头晕的常见成语表达" }
+    ],
+    "testFocus": "Strategy 4 包含匹配（exact + partial 混合；Issue #56 ≥3 条 exact+partial 要求）",
+    "preSegmented": ["今天", "头晕眼花"],
+    "expectedTokens": [
+      { "token": "今天", "matchType": "exact", "labelZh": "今天" },
+      { "token": "头晕眼花", "matchType": "partial", "labelZh": "头晕" }
+    ],
+    "_partialNote": "Strategy 4：token「头晕眼花」长度4，非否定前缀，包含 label「头晕」(2字) → partial 命中",
+    "minMatchRate": 1.0
+  },
+  {
+    "id": "F1",
+    "inputText": "你要去厕所吗",
+    "description": "家属提问句（第二人称 + 是否询问）。「你」精确；「要」走 lexicon→想；「去」「厕所」精确；「吗」为 missing（疑问助词无图）。借鉴自 Codex PR #72 sample #11。",
+    "evidence": [
+      { "source": "Lingraphica-ICU", "note": "ICU 护理沟通中家属/护士常用的基本需求确认句" },
+      { "source": "SCA", "note": "SCA 原则：是/否问题是让患者参与沟通的核心工具" },
+      { "source": "AsTeRICS-Hospital", "note": "Need_for_toilet grid 家属视角提问模式" }
+    ],
+    "testFocus": "家属提问句：第二人称「你」exact + lexicon 路径「要→想」+ 疑问词 missing",
+    "expectedTokens": [
+      { "token": "你", "matchType": "exact", "labelZh": "你" },
+      { "token": "要", "matchType": "lexicon", "labelZh": "想" },
+      { "token": "去", "matchType": "exact", "labelZh": "去" },
+      { "token": "厕所", "matchType": "exact", "labelZh": "厕所" },
+      { "token": "吗", "matchType": "missing", "labelZh": null }
+    ],
+    "minMatchRate": 0.75
+  },
+  {
+    "id": "F2",
+    "inputText": "头痛还是肚子痛",
+    "description": "二选一疼痛确认句。「还是」为 missing（连接词无图）；两侧症状词均需命中。验证连接词不干扰双侧症状匹配。借鉴自 Codex PR #72 sample #18。",
+    "evidence": [
+      { "source": "SCA", "note": "SCA 原则：二选一是失语症患者最容易参与的沟通格式" },
+      { "source": "Lingraphica-ICU", "note": "疼痛部位确认是 ICU 最高频沟通需求之一" },
+      { "source": "AsTeRICS-Hospital", "note": "体部位 + 疼痛 grid 组合场景" }
+    ],
+    "testFocus": "连接词「还是」missing + 双侧症状词独立命中（lexicon 路径「头痛→痛」+ partial 路径「肚子痛→肚子」）",
+    "preSegmented": ["头痛", "还是", "肚子痛"],
+    "expectedTokens": [
+      { "token": "头痛", "matchType": "lexicon", "labelZh": "痛" },
+      { "token": "还是", "matchType": "missing", "labelZh": null },
+      { "token": "肚子痛", "matchType": "partial", "labelZh": "肚子" }
+    ],
+    "_lexiconNote": "词库 痛.synonyms 含「头痛」→ lexicon 命中；「肚子痛」→ Strategy 4 含「肚子」(2字) → partial",
+    "minMatchRate": 0.6
+  },
+  {
+    "id": "F3",
+    "inputText": "先喝水再吃药",
+    "description": "顺序指令句。「先」「再」为 missing（序列副词无图）；「喝水」「吃药」走对应路径命中。借鉴自 Codex PR #72 sample #5。",
+    "evidence": [
+      { "source": "AsTeRICS-Hospital", "note": "医嘱顺序场景：先…再… 结构" },
+      { "source": "SCA", "note": "顺序副词「先/再」是患者/家属日常嘱托高频词，但无 AAC 图片" }
+    ],
+    "testFocus": "序列副词「先」「再」missing；「喝水」exact + 「吃药」lexicon→药",
+    "expectedTokens": [
+      { "token": "先", "matchType": "missing", "labelZh": null },
+      { "token": "喝水", "matchType": "exact", "labelZh": "喝水" },
+      { "token": "再", "matchType": "missing", "labelZh": null },
+      { "token": "吃药", "matchType": "lexicon", "labelZh": "药" }
+    ],
+    "_lexiconNote": "词库 药.synonyms 含「吃药」→ findEntry(吃药) → 药 entry → 命中药图片",
+    "_segmentationNote": "若分词器产生 [先,喝水,再,吃,药]，则 吃+药 各 exact，matchRate=3/5=0.6",
+    "minMatchRate": 0.45
+  },
+  {
+    "id": "F4",
+    "inputText": "不要动等一下",
+    "description": "安全/紧急指令句。「不要」精确命中；「动」为 missing（词库无此运动词）；「等一下」精确命中。借鉴自 Codex PR #72 sample #79。",
+    "evidence": [
+      { "source": "Widgit-26", "note": "Hemsley 26 critical phrases: Don't move / Stop / Wait" },
+      { "source": "SCA", "note": "「不要动」是护理安全场景高频指令" }
+    ],
+    "testFocus": "安全指令：「不要」exact + 「动」missing + 「等一下」exact；验证短 missing 词夹在两个命中词之间不影响已命中词",
+    "expectedTokens": [
+      { "token": "不要", "matchType": "exact", "labelZh": "不要" },
+      { "token": "动", "matchType": "missing", "labelZh": null },
+      { "token": "等一下", "matchType": "exact", "labelZh": "等一下" }
+    ],
+    "_segmentationNote": "若分词器产生 [不要动, 等一下]：「不要动」因 NEGATION_PREFIXES 跳过 Strategy 4，其余策略也无命中 → missing；「等一下」exact",
+    "minMatchRate": 0.6
+  },
+  {
+    "id": "F5",
+    "inputText": "我理解对了吗",
+    "description": "确认/修复回环句（SCA 核心场景）。「我」精确；「理解」为 missing（抽象认知词无图）；「对」走 lexicon→有；「了」「吗」均 missing。测试低匹配率场景。借鉴自 Codex PR #72 sample #57。",
+    "evidence": [
+      { "source": "SCA", "note": "SCA 原则：家属/治疗师确认理解是 AAC 沟通循环的必要环节" },
+      { "source": "Aphasia-Best-Practice", "note": "repair loop（修复回环）是失语症沟通最重要的功能策略之一" }
+    ],
+    "testFocus": "确认回环低覆盖场景：「理解」「了」「吗」均 missing；「对」→ lexicon→有；验证低 matchRate 不崩溃",
+    "expectedTokens": [
+      { "token": "我", "matchType": "exact", "labelZh": "我" },
+      { "token": "理解", "matchType": "missing", "labelZh": null },
+      { "token": "对", "matchType": "lexicon", "labelZh": "有" },
+      { "token": "了", "matchType": "missing", "labelZh": null },
+      { "token": "吗", "matchType": "missing", "labelZh": null }
+    ],
+    "_lexiconNote": "词库 有.synonyms 含「对」(后覆盖 好.synonyms 中同名词条) → findEntry(对) → 有 entry",
+    "minMatchRate": 0.35
+  },
+  {
+    "id": "F6",
+    "inputText": "痛一点点还是很痛",
+    "description": "疼痛程度二选一。「痛」精确命中；「一点点」「还是」「很痛」均 missing（程度词和连接词无图）。验证低覆盖场景并暴露痛感程度词汇缺口。借鉴自 Codex PR #72 sample #22。",
+    "evidence": [
+      { "source": "Lingraphica-ICU", "note": "ICU 疼痛评估：轻度/重度程度询问" },
+      { "source": "Widgit-26", "note": "Hemsley 26: pain intensity scale 沟通需求" }
+    ],
+    "testFocus": "疼痛程度词汇缺口暴露：仅「痛」命中，程度/连接词全为 missing（matchRate=0.25）",
+    "preSegmented": ["痛", "一点点", "还是", "很痛"],
+    "expectedTokens": [
+      { "token": "痛", "matchType": "exact", "labelZh": "痛" },
+      { "token": "一点点", "matchType": "missing", "labelZh": null },
+      { "token": "还是", "matchType": "missing", "labelZh": null },
+      { "token": "很痛", "matchType": "missing", "labelZh": null }
+    ],
+    "_gapNote": "「一点点」「还是」「很痛」三词均不在种子库，暴露疼痛程度量化词汇缺口；可作为扩充词库的优先候选",
+    "minMatchRate": 0.2
+  }
+]

--- a/fixtures/receiver-samples.schema.json
+++ b/fixtures/receiver-samples.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ReceiverSample",
+  "description": "图语家接收端测试样本格式（Issue #55）。evidence / testFocus / _* 字段为扩展注释字段，不影响测试运行。",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "inputText", "expectedTokens"],
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "样本唯一标识，如 A1、C6"
+      },
+      "inputText": {
+        "type": "string",
+        "description": "输入文本（患者/家属原始话语）"
+      },
+      "description": {
+        "type": "string",
+        "description": "样本设计说明"
+      },
+      "evidence": {
+        "type": "array",
+        "description": "按证据来源标注（扩展字段，不参与测试断言）",
+        "items": {
+          "type": "object",
+          "required": ["source"],
+          "properties": {
+            "source": {
+              "type": "string",
+              "enum": [
+                "SCA",
+                "Widgit-26",
+                "Lingraphica-ICU",
+                "AsTeRICS-Hospital",
+                "AsTeRICS-QC24",
+                "LAMP",
+                "2023-Mandarin",
+                "Aphasia-Best-Practice"
+              ],
+              "description": "来源标识：SCA=失语症支持对话原则, Widgit-26=Hemsley 26 critical phrases, Lingraphica-ICU=ICU 沟通板, AsTeRICS-Hospital=医院沟通板, AsTeRICS-QC24=Quick Core 24, LAMP=LAMP Words for Life, 2023-Mandarin=台湾普通话核心词研究, Aphasia-Best-Practice=失语症临床最佳实践"
+            },
+            "note": {
+              "type": "string",
+              "description": "该来源对此样本的具体支持说明"
+            }
+          }
+        }
+      },
+      "testFocus": {
+        "type": "string",
+        "description": "本条样本主要验证的匹配机制（扩展字段）"
+      },
+      "preSegmented": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "（扩展字段）当存在时，测试运行器应调用 matchTextToImages(inputText, { preSegmented }) 跳过自动分词，用于 Strategy 4 partial 路径的确定性测试"
+      },
+      "expectedTokens": {
+        "type": "array",
+        "description": "每个分词 token 的预期匹配类型和标签",
+        "items": {
+          "type": "object",
+          "required": ["token", "matchType"],
+          "properties": {
+            "token": {
+              "type": "string",
+              "description": "分词后的单个 token"
+            },
+            "matchType": {
+              "enum": ["exact", "synonym", "lexicon", "partial", "online", "ai", "missing"],
+              "description": "预期匹配方式"
+            },
+            "labelZh": {
+              "type": ["string", "null"],
+              "description": "命中图片的中文标签；missing 时为 null"
+            }
+          }
+        }
+      },
+      "minMatchRate": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "description": "最低期望匹配率（0-1），测试断言阈值"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add an AAC reference inventory for downloaded public/open AAC materials.
- Document local archive paths, source links, intended use, and licensing boundaries.
- Clarify why raw PDFs, third-party board JSON, and symbol archives are not committed to the app repository.

## Scope
Documentation only. No application code or raw third-party reference files are added.

## Related issues
- #11
- #19
- #30
- #32
- #38