### PR TITLE
docs: add contributor guide and roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,352 @@
+# 贡献指南 · Contributing Guide
+
+欢迎参与图语家开源项目。这份指南帮助你快速了解如何在本地运行项目、如何找到合适的任务、如何提交贡献。
+
+Welcome to PicInterpreter. This guide helps you run the project locally, find suitable tasks, and submit contributions.
+
+---
+
+## 目录 · Contents
+
+- [项目背景](#项目背景)
+- [本地运行](#本地运行)
+- [代码结构](#代码结构)
+- [找到适合你的任务](#找到适合你的任务)
+- [提交 PR](#提交-pr)
+- [UI/UX 规范](#uiux-规范)
+- [测试要求](#测试要求)
+- [非代码贡献](#非代码贡献)
+
+---
+
+## 项目背景
+
+图语家是给**失语症患者和照护者**使用的图片辅助沟通工具。主要解决两个问题：
+
+- **患者表达**：患者选择图片，系统生成候选句并语音播报给家属
+- **接收理解**：家属输入或语音识别文字，系统转成图片序列给患者看
+
+核心设计原则：**离线可用、图标优先、患者侧不暴露技术细节**。
+
+在开始贡献之前，建议先阅读：
+
+- [`docs/decision-index.md`](docs/decision-index.md) — 已确认的架构决策
+- [`AGENTS.md`](AGENTS.md) — UI/UX 规范和实现规则
+- [`docs/implementation-task-index.md`](docs/implementation-task-index.md) — 当前可认领的任务列表
+
+---
+
+## 本地运行
+
+### 前置要求
+
+- Node.js 20+
+- npm
+- MySQL 8.0+（可选，仅云同步 / 认证相关开发需要）
+
+### 克隆和安装
+
+```bash
+git clone https://github.com/picinterpreter/picinterpreter.git
+cd picinterpreter
+npm install
+```
+
+### 环境变量
+
+复制示例文件并按需填写：
+
+```bash
+cp .env.example .env.local
+```
+
+最小运行配置（仅前端 + 本地 IndexedDB）：
+
+```env
+# 如果只跑前端功能，以下变量可以留空或不设置
+DATABASE_URL=
+```
+
+AI 相关功能（可选）：
+
+```env
+AI_API_KEY=your-key
+AI_BASE_URL=https://api.openai.com/v1
+AI_MODEL=gpt-4o-mini
+OPENSYMBOLS_SECRET=your-key
+```
+
+Service Worker（默认关闭）：
+
+```env
+NEXT_PUBLIC_ENABLE_SERVICE_WORKER=false
+```
+
+### 启动开发服务器
+
+```bash
+npm run dev
+```
+
+访问 http://localhost:3001
+
+### 数据库（可选）
+
+如果需要云同步功能：
+
+```bash
+# 创建数据库表结构
+npm run prisma:push
+
+# 或使用迁移（推荐生产环境）
+npx prisma migrate dev
+```
+
+### 常用命令
+
+```bash
+npm run dev          # 启动开发服务器（端口 3001）
+npm run build        # 构建，检查类型和编译错误
+npm run lint         # ESLint 检查
+npm test             # 运行 Vitest 单元测试
+npm run test:watch   # 监听模式运行测试
+npm run test:coverage  # 生成覆盖率报告
+```
+
+**修改 UI 后必须运行 `npm run build` 确认无编译错误，再提交 PR。**
+
+---
+
+## 代码结构
+
+```
+picinterpreter/
+├── app/                    # Next.js App Router 页面和 API 路由
+│   ├── api/               # 服务端 API（AI 代理、同步、认证）
+│   └── ...                # 页面路由
+├── src/
+│   ├── components/        # React 组件（express/、receiver/、emergency/ 等）
+│   ├── db/                # Dexie IndexedDB schema 和 migration
+│   ├── stores/            # Zustand 状态管理
+│   ├── repositories/      # 数据访问层
+│   ├── services/          # 业务服务（匹配 pipeline、TTS 等）
+│   ├── utils/             # 工具函数（分词、AAC 搜索、文本处理）
+│   ├── hooks/             # React 自定义 hooks
+│   ├── types/             # TypeScript 类型定义
+│   └── server/            # 服务端专用代码
+├── prisma/                 # Prisma schema 和 MySQL 迁移
+├── fixtures/               # 测试 fixture 数据
+├── docs/                   # 架构文档、ADR、决策索引
+└── AGENTS.md               # UI/UX 规范（重要！修改 UI 前必读）
+```
+
+### 核心数据流
+
+**表达模式**：`IndexedDB（图片）→ 用户选图 → Zustand 暂存区 → AI/模板候选句 → Web Speech TTS`
+
+**接收模式**：`家属输入文字 → matchTextToImages() pipeline → 图片序列 → 家属修正 → 全屏展示`
+
+**matchTextToImages pipeline**（按顺序）：
+1. 本地分词
+2. 精确匹配 → 同义词匹配 → 词库同义词 → 包含匹配
+3. 未匹配 token → 在线 ARASAAC / OpenSymbols 补图
+4. 仍未匹配或信心低 → AI 重分词 → 重新匹配
+5. 家属手动修正 → 写入修正记录
+
+---
+
+## 找到适合你的任务
+
+### 第一次贡献
+
+推荐从以下 issue 标签开始：
+
+| 标签 | 适合场景 |
+|------|---------|
+| `good first issue` | 文档补充、简单 bug、样式调整、测试补充 |
+| `help wanted` | 功能模块，欢迎外部开发者认领 |
+| `data` | 图库整理、词表、fixture 样本，不需要很多代码经验 |
+
+**当前推荐入口任务（无需深入架构背景）：**
+
+| Issue | 说明 |
+|-------|------|
+| [#16 语音输入波形可视化](https://github.com/picinterpreter/picinterpreter/issues/16) | 接收端语音输入时展示波形动画 |
+| [#36 候选句自动播报](https://github.com/picinterpreter/picinterpreter/issues/36) | 空闲一段时间后自动播报候选句 |
+| [#67 真机验收清单](https://github.com/picinterpreter/picinterpreter/issues/67) | 撰写手机/平板真机测试清单文档 |
+| [#66 离线降级提示](https://github.com/picinterpreter/picinterpreter/issues/66) | 家属侧显示当前离线 / 功能降级状态 |
+
+### 按技术方向找任务
+
+**前端（React / Next.js / IndexedDB / PWA）**
+- 患者端交互优化（触控目标、图标化）
+- 接收端图片序列修正 UI
+- 全屏展示、TTS、离线验收
+- Playwright E2E 测试
+
+**后端 / 全栈（Node.js / Prisma / MySQL）**
+- Dexie schema 迁移和测试
+- ExpressionRecord 接收端字段
+- 同步 outbox 和增量拉取
+- OBF / CBoard 导入
+
+**NLP / AI**
+- 接收端 pipeline 质量（分词、方言归一化、否定句）
+- AI 重分词 prompt 设计
+- 真实样本 fixture 集（参见 `fixtures/` 目录）
+- 信心阈值调参
+
+**无代码 / 文档 / 设计**
+- 核心词库整理（参考 AAC 真实场景）
+- 真实照护沟通场景收集
+- 文档翻译和校对
+- 无障碍审查（是否符合 WCAG 2.1 AA）
+
+---
+
+## 提交 PR
+
+### 1. 认领 issue
+
+在 issue 中留言表示你想处理，避免重复工作。对于涉及架构的任务，建议先在 issue 里对齐方案，再开始编码。
+
+### 2. 分支命名
+
+```
+feat/issue-57-dexie-v5-schema
+fix/receiver-match-order
+docs/contributing-guide
+test/receiver-pipeline-fixtures
+```
+
+### 3. PR 内容
+
+PR 模板会提示你填写以下内容：
+
+- **关联 issue**：`Closes #57`
+- **改动说明**：这个 PR 做了什么、为什么这样做
+- **测试方式**：如何在本地验证这个改动
+- **截图**（如果涉及 UI 改动）
+
+### 4. PR 检查清单
+
+提交前请确认：
+
+- [ ] `npm run build` 无编译错误
+- [ ] `npm run lint` 无新的 ESLint 错误
+- [ ] `npm test` 相关测试通过
+- [ ] 涉及 UI 改动已在移动端小屏下检查（或说明无移动端影响）
+- [ ] 涉及患者侧的改动未引入文字说明、技术错误提示
+- [ ] 不删除已有功能（需要隐藏的复杂信息应移到照护者设置或调试页）
+
+### 5. 代码风格
+
+- TypeScript：项目已配置 ESLint + TypeScript ESLint，提交前跑 lint
+- 不可变数据：避免直接修改对象，用展开运算符或 `structuredClone` 返回新副本
+- 函数小而聚焦，避免超过 50 行
+- 错误处理：每一层都要处理，不要静默吞掉错误
+- 无 `console.log` 残留（调试完毕后清理）
+
+---
+
+## UI/UX 规范
+
+完整规范在 [`AGENTS.md`](AGENTS.md)，以下是核心要点。
+
+### 患者侧（患者可直接看到的界面）
+
+- 图标、颜色、形状优先表达含义，不依赖文字
+- 按钮文案最短：「表达」「接收」「完成」「重播」，不写解释性句子
+- 触控目标 ≥ 44px，关键操作更大，留足间距
+- 错误状态用高可见度状态 + 简短词语：「无法播报」「未找到」，不露技术细节
+- 紧急求助界面：大按钮、强对比、少文字、一次点击播报
+
+### 照护者侧（设置、导入、调试等）
+
+- 可以有说明文字，但要和患者主流程明确分层
+- 不把照护者设置挤进患者正在使用的沟通界面
+
+### 视觉风格
+
+靠近 Apple 系列：浅灰系统背景、克制的半透明面板、胶囊控件、轻阴影、清晰焦点态，不使用花哨装饰。图标使用项目统一的线性图标组件，不用散乱 emoji。
+
+---
+
+## 测试要求
+
+### 单元测试（Vitest）
+
+- 新的匹配逻辑、工具函数、数据转换必须有单元测试
+- Fixture 测试数据放在 `fixtures/` 目录
+- 运行：`npm test`
+
+### 组件测试
+
+- 涉及交互逻辑的组件建议写组件测试
+
+### E2E 测试（Playwright）
+
+- 核心流程改动后，更新或补充 Playwright E2E
+- E2E 测试不应依赖真实 AI / 网络 / 麦克风（使用 mock）
+
+### 真机测试
+
+对于涉及 TTS、全屏、离线、触控的改动，请在手机或平板上验证，或在 PR 中说明无法测试的原因。参见 [#67](https://github.com/picinterpreter/picinterpreter/issues/67)。
+
+---
+
+## 非代码贡献
+
+图语家不只需要代码贡献。以下贡献同样重要：
+
+### 真实场景收集
+
+如果你是照护者、家属或康复从业者，最有价值的贡献是：
+
+- 患者最常需要表达什么（基本需求 / 症状 / 情绪）
+- 家属最常问什么
+- 哪些图片患者看不懂
+- 哪些词系统最容易匹配错
+- 哪些场景必须在没有网络时工作
+
+可以直接在 [GitHub Discussions](https://github.com/picinterpreter/picinterpreter/discussions) 分享，或开一个 issue。
+
+### 核心词库整理
+
+参考 AAC 工具（ARASAAC、Widgit 26、Quick Core 24、Lingraphica ICU 板）和真实照护场景，帮助整理 MVP 核心词表。参见 [#32](https://github.com/picinterpreter/picinterpreter/issues/32)。
+
+### 文档和翻译
+
+- 完善 README、CONTRIBUTING、issue 模板
+- 把关键文档翻译成英文或简体中文
+- 写教程、截图演示、操作视频
+
+### issue 整理
+
+- 帮忙复现 bug 并补充复现步骤
+- 补充缺少 acceptance criteria 的 issue
+- 把大 issue 拆成可操作的小任务
+
+---
+
+## 提问和讨论
+
+- **Bug 和功能请求**：开 [GitHub Issue](https://github.com/picinterpreter/picinterpreter/issues)
+- **架构讨论和开放性问题**：开 [GitHub Discussion](https://github.com/picinterpreter/picinterpreter/discussions)
+- **PR 审查周期**：核心维护者会尽量在 5 个工作日内回复，首次贡献会优先回复
+
+---
+
+## 行为准则
+
+图语家是一个面向特殊需求用户的公益开源项目。参与者应保持：
+
+- 尊重患者、家属、照护者和康复从业者的真实经验
+- 友好、具体、建设性的讨论和代码审查
+- 新贡献者欢迎犯错，维护者会提供具体反馈
+
+---
+
+感谢你花时间了解图语家。一个小 PR、一条真实场景描述、一次文档改进，都可以帮助一个家庭更好地沟通。
+
+Thank you for taking the time to understand PicInterpreter. A small PR, a real-world scenario description, or a documentation improvement can all help a family communicate better.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,143 @@
+# 图语家路线图 · PicInterpreter Roadmap
+
+> 路线图描述产品方向，不是交付承诺。优先级会根据真实用户反馈、贡献者能力和开源协作进展动态调整。  
+> This roadmap describes product direction, not delivery commitments. Priorities will shift based on real user feedback, contributor capacity, and open source collaboration progress.
+
+---
+
+## 现在在做什么 · What We Are Working On Now
+
+**MVP 阶段（2026 Q2 目标）**
+
+核心目标：让失语症患者和家属能够完成一次完整的双向沟通——患者选图表达、家属语音或文字输入转图、无网络时两条链路都能正常工作。
+
+Core goal: let a patient and caregiver complete one full round of two-way communication — patient selects pictures to express; caregiver speaks or types and receives a pictogram sequence; both flows work without network access.
+
+### 正在推进的关键任务 · In Progress
+
+#### P0：接收端持久化 · Receiver Persistence
+
+接收端目前已经可以把输入文字转成图片序列，但沟通过程（家属如何修正图片、最终展示了什么）还没有被记录下来。
+
+The receiver flow can already convert text to pictogram sequences, but the communication process itself (how the caregiver corrected the sequence, what was finally shown) is not yet recorded.
+
+| 任务 | 说明 | Issue |
+|------|------|-------|
+| Dexie v5 schema | 新增 `receiverCorrections`、`missingTokens` 表；Expression 增加 `pictogramSequence`、`recordStatus` 字段 | [#57](https://github.com/picinterpreter/picinterpreter/issues/57) |
+| v4→v5 迁移安全测试 | 验证全新安装、升级、数据保留三条路径 | [#58](https://github.com/picinterpreter/picinterpreter/issues/58) |
+| Prisma 接收端字段 | 服务端 ExpressionRecord 增加对应字段 | [#59](https://github.com/picinterpreter/picinterpreter/issues/59) |
+| 草稿→确认两阶段流程 | 接收端产生草稿记录，全屏展示后确认 | [#60](https://github.com/picinterpreter/picinterpreter/issues/60) |
+| 家属修正事件日志 | 记录替换、删除、排序调整、AI 重写等操作 | [#64](https://github.com/picinterpreter/picinterpreter/issues/64) |
+| 接收历史纳入对话上下文 | 确认的接收记录出现在历史和 LLM 上下文中 | [#63](https://github.com/picinterpreter/picinterpreter/issues/63) |
+
+#### P0：缺失图片工作流 · Missing Pictogram Workflow
+
+当系统找不到图片时，这个缺口应该变成可维护的待办事项，而不是让错误悄悄消失。
+
+When the system cannot find a pictogram, the gap should become a maintainable item, not a silent failure.
+
+| 任务 | 说明 | Issue |
+|------|------|-------|
+| 缺失 token 记录 | 把无法匹配的 token 写入 `MissingTokenRecord` | [#62](https://github.com/picinterpreter/picinterpreter/issues/62) |
+| 家属维护队列 | 让家属能查看、忽略或解决缺失图片 | [#61](https://github.com/picinterpreter/picinterpreter/issues/61) |
+
+#### P1：离线验收 · Offline Validation
+
+| 任务 | 说明 | Issue |
+|------|------|-------|
+| 离线降级状态提示 | 离线时向家属说明哪些功能不可用 | [#66](https://github.com/picinterpreter/picinterpreter/issues/66) |
+| 离线 MVP 行为验证 | 验证应用 shell、本地图库、表达流程、接收手动输入、本地历史在无网状态下可用 | [#65](https://github.com/picinterpreter/picinterpreter/issues/65) |
+
+#### P1：MVP 验收 · MVP Verification
+
+| 任务 | 说明 | Issue |
+|------|------|-------|
+| Playwright E2E | 自动化核心表达和接收流程（不依赖真实 AI / 网络 / 麦克风） | [#68](https://github.com/picinterpreter/picinterpreter/issues/68) |
+| 真机验收清单 | 手动验收触控、TTS、全屏、横竖屏、离线、错误处理 | [#67](https://github.com/picinterpreter/picinterpreter/issues/67) |
+
+---
+
+## 接下来要做什么 · What Comes Next
+
+**MVP 完成后（Phase 2）**
+
+以下工作已经有决策方向，但需要等 MVP 稳定后启动，或者依赖 MVP 验收结论。
+
+The following work has a confirmed direction but needs to wait for MVP stability, or depends on MVP acceptance outcomes.
+
+### 核心词库完善 · Core Pictogram Vocabulary
+
+- 从 ARASAAC 精选 500–800 个 MVP 核心词
+- 参考 Quick Core 24、Widgit 26、Lingraphica ICU 板等 AAC 核心词标准
+- 涵盖基本需求、身体症状、情绪感受、求助场景
+- 验证词库在真实接收场景中的匹配覆盖率
+
+### AAC Board / Button 结构 · AAC Board / Button Structure
+
+图库不再只是"分类文件夹"。引入 Board（导航页）、Button（功能单元）、PictureSet（可复用图片集合）等 AAC 领域标准概念，支持从 OBF（Open Board Format）导入其他 AAC 工具的词板。
+
+The pictogram library is no longer just "category folders." We will introduce AAC concepts like Board (navigation page), Button (functional unit), and PictureSet (reusable pictogram collection), and support importing word boards from other AAC tools via OBF (Open Board Format).
+
+- 设计 Board / Button / PictureSet schema
+- 实现 OBF / CBoard 格式导入
+- 支持 OBZ 导出，方便迁移到其他 AAC 工具
+
+### 接收端 pipeline 质量提升 · Receiver Pipeline Quality
+
+- **粤语/方言归一化优先**：优先覆盖已知用户场景中的高频粤语表达；普通话口语归一化同步推进
+- 否定句保护规则（"不开心"不拆成"不 + 开心"）
+- 后置信心分值阈值调参（基于真实样本 fixture）
+- AI 重分词 prompt 迭代
+- 建立标准化的接收端测试样本集（参见 [#38](https://github.com/picinterpreter/picinterpreter/issues/38) 和 `docs/implementation-task-index.md`）
+
+### 家庭修正记忆 · Family Correction Memory
+
+MVP 阶段只做工作区级即时写回。Phase 2 引入：
+
+MVP implements workspace-level immediate write-back. Phase 2 introduces:
+
+- 修正词条的家庭级推广阈值（默认 ≥3 次修正触发）
+- 修正墓碑机制（90 天过期清理）
+- 修正词条可视化管理界面
+
+---
+
+## 更远的方向 · Longer Horizon
+
+这些方向还在探索中，没有时间承诺，欢迎讨论。
+
+These directions are still being explored. No time commitment. Discussion welcome.
+
+| 方向 | 说明 |
+|------|------|
+| 微信小程序移植 | MVP 网页版稳定后，将核心沟通功能移植为微信小程序，降低安装门槛；依赖 MVP 完成 |
+| 多家庭 workspace | 支持多个患者 / 家庭共用一个应用实例，彼此隔离 |
+| Switch Access 扫描模式 | 支持肢体障碍用户通过单键或双键开关扫描图片 |
+| 相机视觉识别输入 | 患者对准实物拍照，自动识别并匹配图片 |
+| IME 式词语预测 | 患者输入部分图片后，预测最可能的下一张 |
+| 粤语方言 TTS | 粤语语音播报支持（普通话 TTS 已可用）|
+| 线下社区词库包 | 社区贡献的特定场景词库（康复医院、居家护理、学校） |
+| 无障碍认证 | 对照 WCAG 2.1 AA 和 AAC 领域最佳实践做可访问性审计 |
+
+---
+
+## 如何影响路线图 · How to Influence the Roadmap
+
+路线图不是封闭文件。你可以：
+
+The roadmap is not a closed document. You can:
+
+- 在 GitHub Discussions 里提出新方向或质疑现有优先级
+- 通过真实照护场景帮助我们验证或推翻现有假设
+- 认领 `help wanted` 或 `good first issue` 让某个方向更快落地
+- 提供真实使用样本，帮助校准接收端 pipeline 的质量标准
+
+如果你是照护者、康复治疗师或失语症相关从业者，你对真实沟通场景的描述比代码更有价值。
+
+If you are a caregiver, rehabilitation professional, or work in aphasia-related fields, your description of real communication scenarios is more valuable than code.
+
+---
+
+*最后更新：2026-05-02*  
+*Last updated: 2026-05-02*
+<!-- changelog: 粤语方言优先明确写出；微信小程序列入"更远的方向"并注明依赖 MVP 完成 -->

--- a/docs/aac-reference-inventory.md
+++ b/docs/aac-reference-inventory.md
@@ -1,227 +1,259 @@
 # AAC Reference Inventory
 
-This document records the AAC reference materials downloaded for Tuyujia's core pictogram library research.
+This document indexes the AAC reference materials collected for Tuyujia research and development. It covers the local archive, evidence sources used in fixture samples, and additional sources not yet collected.
+
+**Why raw files are not committed to the app repository:**
+- Symbol archives (ARASAAC, Mulberry, Sclera) are large binary assets not suitable for Git
+- Third-party board JSON files (`.grd`, `.obf`, `.obz`) contain content under separate licenses that must not be relicensed under GPL-3.0
+- PDFs and research documents are under academic copyright
+- The app fetches ARASAAC symbols at runtime via the official API; bundling them would violate the CC BY-NC-SA 4.0 attribution requirement
+
+Local archive path: `docs/aac-reference/` (not committed to GitHub)
+
+---
+
+## 1. Pictogram Symbol Libraries
+
+### 1.1 ARASAAC
+
+| Field | Value |
+|-------|-------|
+| Full name | Aragonese Portal of Augmentative and Alternative Communication |
+| URL | https://arasaac.org |
+| Symbol count | ~30,000 pictograms |
+| License | CC BY-NC-SA 4.0 |
+| Language support | Multilingual including Simplified Chinese |
+| Local archive | Not downloaded in bulk; fetched via API at runtime |
+| API | `https://api.arasaac.org/v1/pictograms/{id}` |
+| Used in project | Primary pictogram source; seed library and runtime backfill |
+| Restrictions | Non-commercial only; attribution required; derivative works must use same license |
+| Notes | ARASAAC pictograms use a Western cartoon line-art style. Some concepts (food, clothing, household objects) may have low cultural fit for Chinese users. Medical and body vocabulary is generally universal. |
+
+### 1.2 Mulberry Symbols
+
+| Field | Value |
+|-------|-------|
+| Full name | Mulberry Symbol Set |
+| URL | https://mulberrysymbols.org |
+| Symbol count | ~3,500 symbols |
+| License | CC BY-SA 2.0 |
+| Language support | English primary |
+| Local archive | `docs/aac-reference/mulberry-symbol-info.csv` (metadata only) |
+| Used in project | Reference for vocabulary coverage comparison; not yet in seed library |
+| Restrictions | Attribution required; derivative works must use same license (ShareAlike) |
+| Notes | Adult-oriented, more diverse body representation than ARASAAC. Includes medical, personal care, and emotions. No Chinese label data available. |
+
+### 1.3 Sclera Symbols
+
+| Field | Value |
+|-------|-------|
+| Full name | Sclera Symbol Set |
+| URL | https://www.sclera.be/en/picto/overview |
+| Symbol count | ~13,000 symbols |
+| License | CC BY-NC 2.0 |
+| Language support | Dutch primary; multilingual metadata available |
+| Local archive | Not collected |
+| Used in project | Not yet; candidate for verb/action coverage |
+| Restrictions | Non-commercial only; attribution required |
+| Notes | Simple black-and-white line art style. Research suggests this style is more effective for verbs and abstract concepts than photographic symbols (representational transparency, see issue #74). |
+
+### 1.4 OpenSymbols (aggregator)
+
+| Field | Value |
+|-------|-------|
+| Full name | OpenSymbols.org |
+| URL | https://www.opensymbols.org |
+| License | Per-symbol (aggregates multiple libraries) |
+| Local archive | Not collected; accessed via API at runtime |
+| API | Requires `OPENSYMBOLS_SECRET` env variable |
+| Used in project | Runtime backfill fallback when ARASAAC has no match |
+| Notes | Aggregates ARASAAC, Mulberry, Sclera, and others. License of each result depends on source library. `PictogramSource` field in Dexie schema stores per-symbol license. |
+
+---
+
+## 2. AAC Board Datasets (AsTeRICS Grid)
+
+Source repository: https://github.com/asterics/Asterics-AAC-Data  
+Local archive: `docs/aac-reference/asterics/` and `docs/aac-reference/asterics-aac/` (sparse checkout)  
+Full communicator list: `docs/aac-reference/communicators-list.json` (113 communicators)  
+Format: `.grd.json` (AsTeRICS Grid proprietary format); parser at `docs/aac-reference/parse-grd.cjs`
+
+### 2.1 Communication in Hospital
+
+| Field | Value |
+|-------|-------|
+| Author | Projekt InDiKo, UAS Technikum Wien |
+| Website | https://www.technikum-wien.at/forschungsprojekte/indiko/ |
+| Languages | 22 languages including Chinese (zh) |
+| Tags | BASIC, MEDICAL, HOSPITAL |
+| Local path | `docs/aac-reference/asterics/Communication_in_hospital/` |
+| Used in project | Core reference for hospital scene vocabulary; evidence tag `ASTERICS_HOSPITAL` in fixture samples |
+| Notes | Developed in cooperation with Klinik Floridsdorf, Vienna. Covers: feelings, symptoms, requests, needs, help, pain. 6 scene categories parsed into Chinese fixture samples (scenarios 1–34 in receiver-fixture-samples-evidence.md). |
+
+### 2.2 Quick Core 24
+
+| Field | Value |
+|-------|-------|
+| Author | OpenAAC |
+| Website | https://www.openboardformat.org/examples |
+| License | CC BY-NC-SA 4.0 |
+| Format | OBF (Open Board Format) |
+| Local path | `docs/aac-reference/asterics/Quick_Core_24/` |
+| Used in project | Core vocabulary backbone; evidence tag `ASTERICS_QC24` |
+| Key words | 我 / 想 / 吃 / 喝 / 去 / 好 / 不 / 停 / 什么时候 |
+| Notes | Motor-planning based vocabulary. 24 buttons per board. These 24 core words cover approximately 80% of daily communication needs. They are the minimum viable offline vocabulary for Tuyujia. |
+
+### 2.3 Quick Core 40 / Quick Core 60
+
+| Field | Value |
+|-------|-------|
+| Author | OpenAAC |
+| License | CC BY-NC-SA 4.0 |
+| Local path | `docs/aac-reference/asterics/Quick_Core_40/`, `docs/aac-reference/asterics/Quick_Core_60/` |
+| Used in project | Extended vocabulary reference for Phase 2 expansion |
+| Notes | Superset of Quick Core 24. Useful when expanding beyond the MVP 500–800 word target. |
+
+### 2.4 Global-Core Communicator ARASAAC
+
+| Field | Value |
+|-------|-------|
+| Author | ARASAAC team |
+| Website | https://arasaac.org |
+| Local path | `docs/aac-reference/asterics/Global-Core_Communicator_ARASAAC/` |
+| Used in project | Category structure and vocabulary breadth reference |
+| Notes | Dynamic communicator combining category-based and essential-words layouts. Word prediction enabled. Useful for understanding how ARASAAC organises its own vocabulary taxonomy. |
+
+### 2.5 CommuniKate 20
+
+| Field | Value |
+|-------|-------|
+| Author | Kate McCallum |
+| License | CC BY-NC-SA 4.0 |
+| Local path | `docs/aac-reference/asterics/CommuniKate20/` |
+| Used in project | Adult communicator layout reference |
+| Notes | 20-button layout designed specifically for adult AAC users. Relevant for understanding caregiver-facing interaction patterns and grid density trade-offs. |
 
-The downloaded source files are kept outside the repository at:
-
-```text
-D:/used-by-codex/aac-core-sources
-```
-
-This repository should keep only the **inventory, source links, download notes, intended use, and licensing boundaries**. Do not commit third-party PDFs, symbol archives, or large board JSON files into the app repository unless their licenses and redistribution terms are explicitly reviewed.
-
-## Why The Raw Files Are Not Committed
-
-| Reason | Explanation |
-|---|---|
-| License safety | Several materials are CC BY-NC-SA, PDF handouts, or third-party symbol metadata. Keeping raw files out of the code repo avoids accidentally redistributing assets without review. |
-| Repository size | Some board JSON files are several MB each, and PDF/image assets will grow quickly. |
-| Source-of-truth clarity | The app should use curated seed data, not raw downloaded third-party archives. |
-| Future hosting flexibility | If raw references need to be shared, use a release artifact, cloud storage, or a separate research archive with explicit license notes. |
-
-## Downloaded Local Archive
-
-Local archive root:
-
-```text
-D:/used-by-codex/aac-core-sources
-```
-
-### AsTeRICS AAC Data
-
-Source: https://github.com/asterics/Asterics-AAC-Data
-
-Local folder:
-
-```text
-D:/used-by-codex/aac-core-sources/asterics
-```
-
-| Local file | Approx. size | Extracted scope | Intended use |
-|---|---:|---|---|
-| `quick-core-24.grd.json` | 864 KB | 50 grids, 628 unique labels | Minimal core vocabulary / small grid reference |
-| `quick-core-40.grd.json` | 1.8 MB | 64 grids, 1,669 unique labels | Medium grid vocabulary reference |
-| `quick-core-60.grd.json` | 2.0 MB | 62 grids, 2,004 unique labels | Larger core vocabulary reference |
-| `quick-core-84.grd.json` | 3.6 MB | 78 grids, 3,877 unique labels | Large grid vocabulary reference |
-| `communikate-20_EN.grd.json` | 1.8 MB | 97 grids, 1,162 unique labels | Small-grid communicator reference |
-| `Global-Core_Communicator_ARASAAC_EN.grd.json` | 2.9 MB | 54 grids, 799 unique labels | ARASAAC global-core communicator reference |
-| `communication_hospital.grd.json` | 6.1 MB | 67 grids, 864 unique labels | Hospital / ICU / symptom communication reference |
-
-License boundary:
-
-- AsTeRICS AAC Data README states that source code is AGPL-3.0.
-- Documentation and communication grids are generally CC BY-NC-SA 4.0 unless another license is mentioned in a grid's `info.json`.
-- Treat this as a reference source until each imported item is reviewed.
-
-### Extracted AsTeRICS Labels
-
-Local file:
-
-```text
-D:/used-by-codex/aac-core-sources/metadata/asterics-labels.csv
-```
-
-Rows: 12,140.
-
-Generated from all downloaded AsTeRICS `.grd.json` files. Columns include source file, grid label, row, column, English label, image URL, image author, and action types.
-
-Intended use:
-
-- Candidate vocabulary review.
-- Board structure analysis.
-- Gap analysis for the first offline core library.
-- Not a direct product import without license review.
-
-### Widgit Bedside Messages
-
-Source page: https://widgit-health.com/downloads/bedside-messages.htm
-
-Local folder:
-
-```text
-D:/used-by-codex/aac-core-sources/widgit
-```
-
-| Local file | Intended use |
-|---|---|
-| `Bedside-Messages-Mandarin-A4.pdf` | Mandarin bedside / hospital phrase reference |
-| `Bedside-Messages-Cantonese-A4.pdf` | Cantonese bedside / hospital phrase reference |
-
-License boundary:
-
-- These are PDF/visual materials, not machine-readable vocabularies.
-- Use them for manual phrase extraction and scenario coverage.
-- Do not copy symbols or layouts into the product without checking Widgit's terms.
-
-### Lingraphica Communication Boards
-
-Source page: https://lingraphica.com/free-communication-boards/
-
-Local folder:
-
-```text
-D:/used-by-codex/aac-core-sources/lingraphica
-```
-
-| Local file | Intended use |
-|---|---|
-| `Daily-Activities-Communication-Board.pdf` | Daily activity vocabulary and board layout reference |
-| `ICU-Communication-Board.pdf` | ICU / hospital communication reference |
-| `Pain-Scale-Communication-Board.pdf` | Pain scale reference |
-| `Simple-Communication-Board.pdf` | Small/simple communication board reference |
-| `Conversational-Phrases-Communication-Board.pdf` | Conversation phrase reference |
-| `Emergency-Responder-Comm-Board.pdf` | Emergency response communication reference |
-
-License boundary:
-
-- Use as scenario and board-pattern references.
-- Do not copy symbols or complete board layouts into seed data without license review.
-- PDF content should be manually reviewed before becoming test samples.
-
-### Mulberry Symbols
-
-Source: https://github.com/mulberrysymbols/mulberry-symbols
-
-Local file:
-
-```text
-D:/used-by-codex/aac-core-sources/metadata/mulberry-symbol-info.csv
-```
-
-Rows: 3,436.
-
-Intended use:
-
-- Compare symbol categories, labels, tags, and grammar metadata.
-- Possible alternate symbol source after license review.
-- Useful for designing pictogram metadata.
-
-License boundary:
-
-- Do not import images or metadata into product seed data until license and attribution requirements are reviewed.
-
-### Chinese AAC Clinical Study
-
-Source article: https://trialsjournal.biomedcentral.com/articles/10.1186/s13063-021-05799-0
-
-Local file:
-
-```text
-D:/used-by-codex/aac-core-sources/research/Huang_2021_AAC_post_stroke_aphasia_trial_protocol.pdf
-```
-
-Intended use:
-
-- Chinese post-stroke aphasia AAC context.
-- Clinical vocabulary category reference.
-- Evidence for categories such as vegetables/fruits, daily items, actions, body parts, relatives, and medical staff.
-
-License boundary:
-
-- This is a research paper, not a structured vocabulary file.
-- Use for clinical category evidence and manual review.
-
-## Local Private / User-Provided AAC Exports
-
-These files exist locally but are not copied into the archive or repository because they may include private personal data:
-
-| Local file | Intended use |
-|---|---|
-| `D:/PicInterpreter/export/cboard-all2026-03-08_16-33-14-boardsset board.json` | CBoard structure analysis |
-| `D:/PicInterpreter/export/cboard-export2026-03-08_16-32-12-boardsset board.json` | User daily board structure analysis; contains private names/photos |
-| `D:/PicInterpreter/export/openboard2026-03-08_16-32-54-日常使用黄炳灿制作 board.obf` | OBF import compatibility analysis |
-
-Boundary:
-
-- Use for structure only.
-- Do not publish private names, photos, or user-specific locations in seed data.
-
-## Not Downloaded / Reference Only
-
-| Source | Link | Reason |
-|---|---|---|
-| Taiwanese Mandarin AAC core vocabulary study | https://www.tandfonline.com/doi/abs/10.1080/07434618.2023.2199855 | Full 100-word list was not found as a public structured download. |
-| Mandarin AphasiaBank core lexicon analysis | https://pubmed.ncbi.nlm.nih.gov/36866943/ | Research abstract/reference only; not an AAC seed vocabulary download. |
-| PRC-Saltillo vocabularies | https://prc-saltillo.com/vocabularies | Commercial vocabulary system; use as product-pattern reference only. |
-| Communication Journey: Aphasia | https://prc-saltillo.com/vocabularies/communication-journey | Commercial aphasia vocabulary; do not copy content without permission. |
-| Proloquo2Go / Crescendo | https://www.assistiveware.com/products/proloquo2go | Commercial vocabulary; use as pattern reference only. |
-| TD Snap Core First | https://www.tobiidynavox.com/products/td-snap | Commercial vocabulary; use as pattern reference only. |
-| TouchChat / WordPower | https://touchchatapp.com/ | Commercial vocabulary; use as pattern reference only. |
-| LAMP Words for Life | https://aacapps.com/lamp/ | Commercial vocabulary; use as motor-planning / stable-layout reference only. |
-| Avaz AAC | https://www.avazapp.com/ | Commercial AAC product; use as onboarding/category reference only. |
-| ARASAAC full keyword database | https://arasaac.org/ | No stable full batch keyword download was found. Use candidate word -> API search -> metadata cache -> manual review. |
-
-## Recommended Product Workflow
-
-Create a working spreadsheet with these columns:
-
-```text
-source
-source_file
-source_label
-suggested_zh
-category
-core_or_fringe
-must_offline
-image_source
-license
-reuse_level
-notes
-```
-
-Recommended extraction order:
-
-1. AsTeRICS Quick Core 24 / 40 / 60.
-2. ARASAAC Global-Core Communicator.
-3. AsTeRICS Communication in hospital.
-4. Widgit Mandarin / Cantonese Bedside Messages.
-5. Lingraphica ICU / pain scale / emergency / daily boards.
-6. Chinese clinical study categories.
-7. Local CBoard structures.
-8. Mulberry metadata for category/tag comparison.
-
-## Product Boundary
-
-The offline core pictogram library should be derived from mature AAC vocabularies, open AAC boards, ARASAAC / AsTeRICS / CBoard structures, and clinical vocabulary references.
-
-Receiver fixture samples should be used for coverage validation and gap detection only. They should not become the primary source for defining the core library.
+---
+
+## 3. Research-Backed Communication Resources
+
+### 3.1 Widgit / Hemsley 26 Critical Phrases
+
+| Field | Value |
+|-------|-------|
+| Reference | Hemsley B. et al. "26 Critical Health Phrases for People with Communication Disability" (2012) |
+| Evidence tag | `WIDGIT_BEDSIDE` |
+| Used in project | Fixture sample design; bedside hospital communication patterns |
+| Phrases covered | Pain location, severity, needs, requests for staff, yes/no confirmation, environmental requests |
+| Notes | 26 phrases identified as critical for hospitalized patients who cannot speak. Adapted (not copied) into Chinese caregiver utterances in fixture samples. Source is publicly documented in academic literature. |
+
+### 3.2 Lingraphica ICU / Hospital Communication Boards
+
+| Field | Value |
+|-------|-------|
+| Source | Lingraphica free AAC boards — https://www.lingraphica.com/free-aac-boards/ |
+| Evidence tag | `LINGRAPHICA_BOARD` |
+| Used in project | ICU and daily communication pattern reference for fixture samples |
+| Notes | Publicly available boards for people with aphasia. Covers: pain scale, yes/no responses, basic needs, medical requests. Patterns adapted (not copied) for Chinese fixture samples (42 samples in receiver-fixture-samples-evidence.md reference this tag). |
+
+### 3.3 SCA — Supported Conversation for Adults with Aphasia
+
+| Field | Value |
+|-------|-------|
+| Source | Aphasia Institute, Toronto — https://www.aphasia.ca/sca/ |
+| Evidence tag | `SCA_APHASIA` |
+| Used in project | Core communication strategy principles; evidence basis for receiver pipeline design |
+| Key principles | Patients use single keywords or 1–3 word utterances; caregivers should offer binary choices, use yes/no questions, confirm understanding |
+| Notes | These principles directly inform the receiver pipeline design: short caregiver input → pictogram sequence → patient review → caregiver correction. Also informs the patient-facing UI requirement of ≤3 steps to complete an expression. |
+
+### 3.4 LAMP Words for Life
+
+| Field | Value |
+|-------|-------|
+| Source | PRC-Saltillo — https://www.prentrom.com/lamp |
+| Evidence tag | `LAMP` |
+| Used in project | Motor-planning vocabulary structure reference |
+| Notes | LAMP (Language Acquisition through Motor Planning) emphasises consistent motor patterns for core words. Informs why core words should occupy stable, prominent positions in the patient-facing grid and why grid layout should not change between categories. Commercial product; patterns referenced, content not reproduced. |
+
+### 3.5 2023 Mandarin Core Vocabulary Study (Taiwan)
+
+| Field | Value |
+|-------|-------|
+| Reference | Chinese-language AAC core vocabulary research for Mandarin speakers (Taiwan, 2023) |
+| Evidence tag | `2023-Mandarin` |
+| Used in project | Mandarin-specific core vocabulary categories |
+| Notes | Identifies high-frequency Mandarin words used by AAC users and caregivers in Taiwan context. Particularly relevant for corpus-driven core vocabulary selection (issue #11, #32). Simplified/Traditional Chinese mapping needed for mainland users. Full citation to be confirmed. |
+
+### 3.6 Aphasia Best Practice (Clinical Guidelines)
+
+| Field | Value |
+|-------|-------|
+| Source | Clinical AAC best practice literature; Aphasia Institute SCA principles |
+| Evidence tag | `Aphasia-Best-Practice` |
+| Used in project | Foundational principles for patient-facing UI design and pipeline expectations |
+| Notes | Informs: icon-first patient UI (issue #6), ≤3-step interaction requirement, offline-first guarantee (issue #32), caregiver correction flow (issue #26). Referenced in AGENTS.md and architecture decision index. |
+
+---
+
+## 4. Open Board Format (OBF) Sources
+
+OBF is the open standard for AAC board exchange: https://www.openboardformat.org
+
+| Source | Format | License | Status | Notes |
+|--------|--------|---------|--------|-------|
+| CBoard export | OBF / OBZ | User data | Collected locally | Categories and board structure extracted; evidence tag `LOCAL_CBOARD_EXPORT` in fixture samples |
+| OpenAAC examples | OBF | CC BY-NC-SA 4.0 | Collected | Quick Core boards above |
+| Snap Core First | OBZ | Commercial | Not collected | Reference only |
+| Proloquo2Go | Proprietary | Commercial | Not collected | Reference only |
+| TouchChat | Proprietary | Commercial | Not collected | Reference only |
+
+OBF import support is planned for Phase 2 (issue #30). When implemented, imported OBF content will carry the source license in `PictogramSource` and will not merge with or override the app's seed library.
+
+---
+
+## 5. Chinese / Cantonese-Specific Gaps
+
+The following sources have been identified as relevant but not yet collected. These are the highest-priority gaps for improving Tuyujia's fit for Chinese-speaking users.
+
+| Source | Type | Priority | Action needed |
+|--------|------|----------|---------------|
+| Hong Kong AAC resources (SAHK) | Cantonese board sets and vocabulary | **High** | Contact Spastic Association of Hong Kong; Cantonese is Tuyujia's first-priority dialect |
+| 中文沟通板（大陆医院康复科） | Hospital communication boards | **High** | Collect PDF samples from mainland rehabilitation hospitals; convert vocabulary to fixture samples |
+| 台湾中文 AAC 词库 | Vocabulary lists (Traditional Chinese) | Medium | Obtain from 2023-Mandarin study authors; map Traditional → Simplified Chinese |
+| 中国失语症康复指南 | Clinical guidelines | Medium | Chinese clinical rehabilitation guidelines for aphasia; validate vocabulary against clinical standard |
+| 粤语核心词研究 | Academic research | Low (Phase 2) | Cantonese-specific core vocabulary studies; not yet located as open publication |
+| 失语症家属照护手册 | Caregiver guides | Medium | Mainland Chinese patient/caregiver guides published by hospitals or patient associations |
+
+---
+
+## 6. Fixture Sample Evidence Map
+
+The fixture samples in `fixtures/receiver-samples.json` and `docs/receiver-fixture-samples-evidence.md` draw from the sources above. Evidence tags map as follows:
+
+| Evidence tag | Source |
+|--------------|--------|
+| `WIDGIT_BEDSIDE` | §3.1 Hemsley 26 Critical Phrases |
+| `ASTERICS_HOSPITAL` | §2.1 Communication in Hospital |
+| `LINGRAPHICA_BOARD` | §3.2 Lingraphica boards |
+| `CHINA_RCT_WORDS` | §3.5 2023 Mandarin study |
+| `SCA_APHASIA` | §3.3 SCA principles |
+| `LOCAL_CBOARD_EXPORT` | §4 CBoard export |
+| `AAC_PRODUCT_PATTERN` | §3.4 LAMP / commercial product patterns (structure only) |
+| `SYNTHETIC_CN_CARE` | Adapted from all above; no single direct source |
+
+---
+
+## 7. How to Add New Reference Material
+
+1. Check the license before downloading. Materials with NC (non-commercial) clauses are fine for research and fixture design but cannot be bundled into a GPL-3.0 app binary.
+2. If the license permits local storage, place files under `docs/aac-reference/<source-name>/`.
+3. Add an entry to this document under the appropriate section.
+4. If the material informs fixture samples, add a corresponding evidence tag to `receiver-samples.schema.json` (the `evidence[].source` enum).
+5. Do **not** commit raw symbol files, PDFs, or third-party board JSON to the GitHub repository. Add the path to `.gitignore` and document the local path here instead.
+6. If the material reveals vocabulary gaps (concepts with no matching pictogram), add them to the missing token tracking workflow (issue #19, #62).
+
+---
+
+*Last updated: 2026-05-02*  
+*Closes: #75*  
+*Related issues: #11 #19 #30 #32 #38 #74*

--- a/docs/aac-reference-inventory.md
+++ b/docs/aac-reference-inventory.md
@@ -1,0 +1,227 @@
+# AAC Reference Inventory
+
+This document records the AAC reference materials downloaded for Tuyujia's core pictogram library research.
+
+The downloaded source files are kept outside the repository at:
+
+```text
+D:/used-by-codex/aac-core-sources
+```
+
+This repository should keep only the **inventory, source links, download notes, intended use, and licensing boundaries**. Do not commit third-party PDFs, symbol archives, or large board JSON files into the app repository unless their licenses and redistribution terms are explicitly reviewed.
+
+## Why The Raw Files Are Not Committed
+
+| Reason | Explanation |
+|---|---|
+| License safety | Several materials are CC BY-NC-SA, PDF handouts, or third-party symbol metadata. Keeping raw files out of the code repo avoids accidentally redistributing assets without review. |
+| Repository size | Some board JSON files are several MB each, and PDF/image assets will grow quickly. |
+| Source-of-truth clarity | The app should use curated seed data, not raw downloaded third-party archives. |
+| Future hosting flexibility | If raw references need to be shared, use a release artifact, cloud storage, or a separate research archive with explicit license notes. |
+
+## Downloaded Local Archive
+
+Local archive root:
+
+```text
+D:/used-by-codex/aac-core-sources
+```
+
+### AsTeRICS AAC Data
+
+Source: https://github.com/asterics/Asterics-AAC-Data
+
+Local folder:
+
+```text
+D:/used-by-codex/aac-core-sources/asterics
+```
+
+| Local file | Approx. size | Extracted scope | Intended use |
+|---|---:|---|---|
+| `quick-core-24.grd.json` | 864 KB | 50 grids, 628 unique labels | Minimal core vocabulary / small grid reference |
+| `quick-core-40.grd.json` | 1.8 MB | 64 grids, 1,669 unique labels | Medium grid vocabulary reference |
+| `quick-core-60.grd.json` | 2.0 MB | 62 grids, 2,004 unique labels | Larger core vocabulary reference |
+| `quick-core-84.grd.json` | 3.6 MB | 78 grids, 3,877 unique labels | Large grid vocabulary reference |
+| `communikate-20_EN.grd.json` | 1.8 MB | 97 grids, 1,162 unique labels | Small-grid communicator reference |
+| `Global-Core_Communicator_ARASAAC_EN.grd.json` | 2.9 MB | 54 grids, 799 unique labels | ARASAAC global-core communicator reference |
+| `communication_hospital.grd.json` | 6.1 MB | 67 grids, 864 unique labels | Hospital / ICU / symptom communication reference |
+
+License boundary:
+
+- AsTeRICS AAC Data README states that source code is AGPL-3.0.
+- Documentation and communication grids are generally CC BY-NC-SA 4.0 unless another license is mentioned in a grid's `info.json`.
+- Treat this as a reference source until each imported item is reviewed.
+
+### Extracted AsTeRICS Labels
+
+Local file:
+
+```text
+D:/used-by-codex/aac-core-sources/metadata/asterics-labels.csv
+```
+
+Rows: 12,140.
+
+Generated from all downloaded AsTeRICS `.grd.json` files. Columns include source file, grid label, row, column, English label, image URL, image author, and action types.
+
+Intended use:
+
+- Candidate vocabulary review.
+- Board structure analysis.
+- Gap analysis for the first offline core library.
+- Not a direct product import without license review.
+
+### Widgit Bedside Messages
+
+Source page: https://widgit-health.com/downloads/bedside-messages.htm
+
+Local folder:
+
+```text
+D:/used-by-codex/aac-core-sources/widgit
+```
+
+| Local file | Intended use |
+|---|---|
+| `Bedside-Messages-Mandarin-A4.pdf` | Mandarin bedside / hospital phrase reference |
+| `Bedside-Messages-Cantonese-A4.pdf` | Cantonese bedside / hospital phrase reference |
+
+License boundary:
+
+- These are PDF/visual materials, not machine-readable vocabularies.
+- Use them for manual phrase extraction and scenario coverage.
+- Do not copy symbols or layouts into the product without checking Widgit's terms.
+
+### Lingraphica Communication Boards
+
+Source page: https://lingraphica.com/free-communication-boards/
+
+Local folder:
+
+```text
+D:/used-by-codex/aac-core-sources/lingraphica
+```
+
+| Local file | Intended use |
+|---|---|
+| `Daily-Activities-Communication-Board.pdf` | Daily activity vocabulary and board layout reference |
+| `ICU-Communication-Board.pdf` | ICU / hospital communication reference |
+| `Pain-Scale-Communication-Board.pdf` | Pain scale reference |
+| `Simple-Communication-Board.pdf` | Small/simple communication board reference |
+| `Conversational-Phrases-Communication-Board.pdf` | Conversation phrase reference |
+| `Emergency-Responder-Comm-Board.pdf` | Emergency response communication reference |
+
+License boundary:
+
+- Use as scenario and board-pattern references.
+- Do not copy symbols or complete board layouts into seed data without license review.
+- PDF content should be manually reviewed before becoming test samples.
+
+### Mulberry Symbols
+
+Source: https://github.com/mulberrysymbols/mulberry-symbols
+
+Local file:
+
+```text
+D:/used-by-codex/aac-core-sources/metadata/mulberry-symbol-info.csv
+```
+
+Rows: 3,436.
+
+Intended use:
+
+- Compare symbol categories, labels, tags, and grammar metadata.
+- Possible alternate symbol source after license review.
+- Useful for designing pictogram metadata.
+
+License boundary:
+
+- Do not import images or metadata into product seed data until license and attribution requirements are reviewed.
+
+### Chinese AAC Clinical Study
+
+Source article: https://trialsjournal.biomedcentral.com/articles/10.1186/s13063-021-05799-0
+
+Local file:
+
+```text
+D:/used-by-codex/aac-core-sources/research/Huang_2021_AAC_post_stroke_aphasia_trial_protocol.pdf
+```
+
+Intended use:
+
+- Chinese post-stroke aphasia AAC context.
+- Clinical vocabulary category reference.
+- Evidence for categories such as vegetables/fruits, daily items, actions, body parts, relatives, and medical staff.
+
+License boundary:
+
+- This is a research paper, not a structured vocabulary file.
+- Use for clinical category evidence and manual review.
+
+## Local Private / User-Provided AAC Exports
+
+These files exist locally but are not copied into the archive or repository because they may include private personal data:
+
+| Local file | Intended use |
+|---|---|
+| `D:/PicInterpreter/export/cboard-all2026-03-08_16-33-14-boardsset board.json` | CBoard structure analysis |
+| `D:/PicInterpreter/export/cboard-export2026-03-08_16-32-12-boardsset board.json` | User daily board structure analysis; contains private names/photos |
+| `D:/PicInterpreter/export/openboard2026-03-08_16-32-54-日常使用黄炳灿制作 board.obf` | OBF import compatibility analysis |
+
+Boundary:
+
+- Use for structure only.
+- Do not publish private names, photos, or user-specific locations in seed data.
+
+## Not Downloaded / Reference Only
+
+| Source | Link | Reason |
+|---|---|---|
+| Taiwanese Mandarin AAC core vocabulary study | https://www.tandfonline.com/doi/abs/10.1080/07434618.2023.2199855 | Full 100-word list was not found as a public structured download. |
+| Mandarin AphasiaBank core lexicon analysis | https://pubmed.ncbi.nlm.nih.gov/36866943/ | Research abstract/reference only; not an AAC seed vocabulary download. |
+| PRC-Saltillo vocabularies | https://prc-saltillo.com/vocabularies | Commercial vocabulary system; use as product-pattern reference only. |
+| Communication Journey: Aphasia | https://prc-saltillo.com/vocabularies/communication-journey | Commercial aphasia vocabulary; do not copy content without permission. |
+| Proloquo2Go / Crescendo | https://www.assistiveware.com/products/proloquo2go | Commercial vocabulary; use as pattern reference only. |
+| TD Snap Core First | https://www.tobiidynavox.com/products/td-snap | Commercial vocabulary; use as pattern reference only. |
+| TouchChat / WordPower | https://touchchatapp.com/ | Commercial vocabulary; use as pattern reference only. |
+| LAMP Words for Life | https://aacapps.com/lamp/ | Commercial vocabulary; use as motor-planning / stable-layout reference only. |
+| Avaz AAC | https://www.avazapp.com/ | Commercial AAC product; use as onboarding/category reference only. |
+| ARASAAC full keyword database | https://arasaac.org/ | No stable full batch keyword download was found. Use candidate word -> API search -> metadata cache -> manual review. |
+
+## Recommended Product Workflow
+
+Create a working spreadsheet with these columns:
+
+```text
+source
+source_file
+source_label
+suggested_zh
+category
+core_or_fringe
+must_offline
+image_source
+license
+reuse_level
+notes
+```
+
+Recommended extraction order:
+
+1. AsTeRICS Quick Core 24 / 40 / 60.
+2. ARASAAC Global-Core Communicator.
+3. AsTeRICS Communication in hospital.
+4. Widgit Mandarin / Cantonese Bedside Messages.
+5. Lingraphica ICU / pain scale / emergency / daily boards.
+6. Chinese clinical study categories.
+7. Local CBoard structures.
+8. Mulberry metadata for category/tag comparison.
+
+## Product Boundary
+
+The offline core pictogram library should be derived from mature AAC vocabularies, open AAC boards, ARASAAC / AsTeRICS / CBoard structures, and clinical vocabulary references.
+
+Receiver fixture samples should be used for coverage validation and gap detection only. They should not become the primary source for defining the core library.


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md** — bilingual contributor guide covering local setup, code structure, issue discovery, PR workflow, UI/UX rules, testing requirements, and non-code contribution paths
- **ROADMAP.md** — bilingual product roadmap with current P0/P1 tasks (linked to issues), Phase 2 direction, and longer-horizon items

## Changes from review feedback

- MySQL moved to optional prerequisite (reduces onboarding friction)
- Env var names corrected to `AI_API_KEY / AI_BASE_URL / AI_MODEL` (matches `.env.example`)
- Directory tree updated to reflect actual `src/` structure
- Cantonese priority scoped to "known user scenarios" (removed unsupported statistical claim)
- Fixture sample reference updated from closed #55/#56 → active #38 + `docs/implementation-task-index.md`

## Scope

Documentation only. No `package-lock.json`, no `docs/architecture-evaluation.md`.

## Related issues

#38 #67 #68