### PR TITLE
docs: add live demo link to README and recruitment posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Original repository: https://github.com/lightcoloror/PicInterpreter
 
 # Tuyujia
 
+**[🔗 Live Demo → aac.pairlab.cn](https://aac.pairlab.cn/)**
+
 Tuyujia is a picture-based assisted communication app for people with aphasia and their caregivers. Users can express needs by selecting pictures, then the system generates candidate sentences and reads them aloud. It also supports converting caregiver-entered text or speech back into picture sequences to help patients understand.
 
 The project currently uses `Next.js + React 19 + TypeScript`, with `Dexie` for local `IndexedDB` data. AI requests are routed through the Next.js backend under `app/api`, so the frontend no longer stores any API keys or tokens.

--- a/README_cn.md
+++ b/README_cn.md
@@ -1,6 +1,8 @@
 原仓库地址： https://github.com/lightcoloror/PicInterpreter
 # 图语家
 
+**[🔗 在线演示 → aac.pairlab.cn](https://aac.pairlab.cn/)**
+
 图语家是一个面向失语症患者和照护者的图片辅助沟通应用。用户可以通过点选图片表达需求，由系统生成候选句子并朗读出来；也支持把照护者输入的文字或语音反向转换为图片序列，帮助患者理解。
 
 项目当前采用 `Next.js + React 19 + TypeScript` 构建，使用 `Dexie` 管理本地 `IndexedDB` 数据。AI 相关请求统一通过 Next.js 后端 `app/api` 转发，前端不再保存任何 API Key 或 Token。

--- a/docs/community-recruitment-developer-short-bilingual.md
+++ b/docs/community-recruitment-developer-short-bilingual.md
@@ -61,6 +61,10 @@ How we collaborate:
 - If you are not sure whether you are a fit, start with a 15-minute trial: read the README, ask one question, claim a small issue, or share the project with one person who may care.
 - We will avoid treating volunteers as free labor: no empty promises, no forced long-term commitment, and requirement changes should be explained with discussion history preserved.
 
+在线演示：https://aac.pairlab.cn/
+
+Live demo: https://aac.pairlab.cn/
+
 项目地址：  
 https://github.com/picinterpreter/picinterpreter
 

--- a/docs/community-recruitment-social-short-bilingual.md
+++ b/docs/community-recruitment-social-short-bilingual.md
@@ -52,6 +52,10 @@ We will try to break tasks into small pieces that can be done in 1–3 hours. We
 
 If you know developers, university tech clubs, rehabilitation professionals, accessibility communities, or tech-for-good groups, please help share it with them.
 
+在线演示：https://aac.pairlab.cn/
+
+Live demo: https://aac.pairlab.cn/
+
 GitHub：  
 https://github.com/picinterpreter/picinterpreter
 


### PR DESCRIPTION
## Summary

Add live demo link `https://aac.pairlab.cn/` to all entry points:

- `README.md` — English, above project description
- `README_cn.md` — Chinese, above project description
- `docs/community-recruitment-social-short-bilingual.md` — above GitHub link
- `docs/community-recruitment-developer-short-bilingual.md` — above GitHub link

## Why

Demo was already live but not referenced anywhere in the repository. Every outreach channel (HelloGitHub, Reddit, Dev.to, Discord, etc.) asks "can I try it immediately?" — this removes that blocker.

## Related

- #7 (demo version tracking issue — added comment noting demo is live)